### PR TITLE
Support docker deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM registry.cn-hangzhou.aliyuncs.com/mse-ingress/higress-docsite-base:v1
+
+WORKDIR /higress
+
+COPY . .
+
+RUN docsite build
+
+ENTRYPOINT ["python", "-m", "SimpleHTTPServer", "8080"]

--- a/Dockerfile-Base
+++ b/Dockerfile-Base
@@ -1,0 +1,35 @@
+FROM debian:latest
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt-get update \
+    && apt-get install -y curl python2 \
+    && ln -s /usr/bin/python2 /usr/bin/python \
+    && apt-get -y autoclean
+
+RUN mkdir /usr/local/nvm
+ENV NVM_DIR /usr/local/nvm
+ENV NODE_VERSION 8.16.0
+ENV NVM_INSTALL_PATH $NVM_DIR/versions/node/v$NODE_VERSION
+
+RUN curl --silent -o- https://raw.githubusercontent.com/creationix/nvm/v0.31.2/install.sh | bash
+
+RUN source $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION \
+    && nvm use default
+
+ENV NODE_PATH $NVM_INSTALL_PATH/lib/node_modules
+ENV PATH $NVM_INSTALL_PATH/bin:$PATH
+
+RUN node -v
+RUN npm -v
+
+WORKDIR /higress
+
+COPY . .
+
+RUN npm config set registry https://registry.npmmirror.com
+RUN npm install --save-dev @babel/core
+RUN npm install docsite@1.3.8 -g --unsafe-perm
+RUN npm i -g --unsafe-perm

--- a/README.md
+++ b/README.md
@@ -8,11 +8,29 @@ All website material  of https://higress.io
 ## Prerequisite
 
 higress-group.github.io is powered by [docsite](https://github.com/txd-team/docsite).please read [https://docsite.js.org](https://docsite.js.org) 
+
+## Build instruction
+
+### Docker deploy (Recommand)
+1. Docker build the target image.
+```
+docker build -t higress-docsite .
+```
+2. Docker run the target image.
+```
+docker run -p 8080:8080 higress-docsite
+```
+3. Now you can view the changed document in your local machine.
+```
+localhost:8080/
+```
+
+> Note: When the dependencies changes, the code owners of this project should rebuild the higress-docsite-base by Dockerfile named Dockerfile-Base.
+
+### Local deploy
 If your version of docsite is less than `1.3.3`, please upgrade to at least `1.3.3`,`1.3.8` is recommended.
 
 Please also make sure your node version is 8.x, versions higher than 8.x is not supported by docsite yet.
-
-## Build instruction
 
 1. Run `npm install docsite -g` to install the dev tool.
 2. Run `npm i` in the root directory to install the dependencies.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 
 All website material  of https://higress.io
 
-
-## Prerequisite
-
-higress-group.github.io is powered by [docsite](https://github.com/txd-team/docsite).please read [https://docsite.js.org](https://docsite.js.org) 
-
 ## Build instruction
 
 ### Docker deploy (Recommand)
@@ -28,7 +23,7 @@ localhost:8080/
 > Note: When the dependencies changes, the code owners of this project should rebuild the higress-docsite-base by Dockerfile named Dockerfile-Base.
 
 ### Local deploy
-If your version of docsite is less than `1.3.3`, please upgrade to at least `1.3.3`,`1.3.8` is recommended.
+higress-group.github.io is powered by [docsite](https://github.com/txd-team/docsite).please read [https://docsite.js.org](https://docsite.js.org) . If your version of docsite is less than `1.3.3`, please upgrade to at least `1.3.3`,`1.3.8` is recommended.
 
 Please also make sure your node version is 8.x, versions higher than 8.x is not supported by docsite yet.
 


### PR DESCRIPTION
Since the way of local deploy is difficult for most users, we provide the way of docker deploy to help users to contribute the higress docsite together.

Fix https://github.com/higress-group/higress-group.github.io/issues/27.