### PR TITLE
fix typo from `ture` to `true`

### DIFF
--- a/i18n/en-us/docusaurus-plugin-content-docs/current/plugins/jwt-auth.md
+++ b/i18n/en-us/docusaurus-plugin-content-docs/current/plugins/jwt-auth.md
@@ -239,7 +239,7 @@ The configuration field descriptions for each item in consumers are as follows:
 | `from_params`           | array of string   | Optional     | access_token    | Extracts the JWT from the specified URL parameters     |
 | `from_cookies`          | array of string   | Optional     | -    | Extracts the JWT from the specified cookie(s)     |
 | `clock_skew_seconds`    | number            | Optional     | 60     | The amount of clock skew, in seconds, that is allowed when verifying the exp and iat fields of the JWT          |
-| `keep_token`            | bool              | Optional     | ture   | Whether to keep the JWT when forwarding it to the backend  |
+| `keep_token`            | bool              | Optional     | true   | Whether to keep the JWT when forwarding it to the backend  |
 
 **Note:**
 

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/jwt-auth.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/jwt-auth.md
@@ -33,7 +33,7 @@ description: JWT 认证插件配置参考
 | `from_params`           | array of string   | 选填     | access_token                                      | 从指定的URL参数中抽取JWT                                   |
 | `from_cookies`          | array of string   | 选填     | -                                                 | 从指定的cookie中抽取JWT                                    |
 | `clock_skew_seconds`    | number            | 选填     | 60                                                | 校验JWT的exp和iat字段时允许的时钟偏移量，单位为秒          |
-| `keep_token`            | bool              | 选填     | ture                                              | 转发给后端时是否保留JWT                                    |
+| `keep_token`            | bool              | 选填     | true                                              | 转发给后端时是否保留JWT                                    |
 
 **注意：** 
 - 只有当`from_headers`,`from_params`,`from_cookies`均未配置时，才会使用默认值


### PR DESCRIPTION
fix typo from `ture` to `true`