### PR TITLE
fix: Update annotation-use-case.md

### DIFF
--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/annotation-use-case.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/user/annotation-use-case.md
@@ -167,7 +167,7 @@ spec:
 
 ### 基于权重灰度发布
 - higress.io/canary-weight：设置请求到指定服务的百分比（值为0~100的整数）
-- higress.io/canary-weight-totatl：设置权重总和，默认为100
+- higress.io/canary-weight-total：设置权重总和，默认为100
 
 配置灰度服务demo-service-canary-v1的权重为30%，配置灰度服务demo-service-canary-v2的权重为20%，配置正式服务demo-service的权重为50%。
 ```


### PR DESCRIPTION
Correct a word spelling error

[alibaba/higress](https://github.com/alibaba/higress)
pkg\ingress\kube\annotations\canary.go Line 28 
Confirm the correct spelling of this annotation
```go
const (
	enableCanary          = "canary"
	canaryByHeader        = "canary-by-header"
	canaryByHeaderValue   = "canary-by-header-value"
	canaryByHeaderPattern = "canary-by-header-pattern"
	canaryByCookie        = "canary-by-cookie"
	canaryWeight          = "canary-weight"
	canaryWeightTotal     = "canary-weight-total"

	defaultCanaryWeightTotal = 100
)
```

已在 [higress 主项目](https://github.com/alibaba/higress)
pkg\ingress\kube\annotations\canary.go 28行 确认此注解的正确拼写