### PR TITLE
fix code-reading guide

### DIFF
--- a/i18n/en-us/docusaurus-plugin-content-docs/current/dev/code.md
+++ b/i18n/en-us/docusaurus-plugin-content-docs/current/dev/code.md
@@ -36,7 +36,8 @@ If you would like to modify the source code of envoy or istio, you can do it dir
 ```bash
 mv external/envoy external/envoy_new
 make prebuild
-diff -Naur external/envoy external/envoy_new > envoy/1.20/patches/envoy/$(date +%Y%m%d)-what-changed.patch
+cd external
+diff -Naur envoy envoy_new > ../envoy/1.20/patches/envoy/$(date +%Y%m%d)-what-changed.patch
 ```
 
 Please be aware that patches will be applied in the order of file names. So please use timestamp as a prefix when naming a new patch file.

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/dev/code.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/dev/code.md
@@ -36,7 +36,8 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 ```bash
 mv external/envoy external/envoy_new
 make prebuild
-diff -Naur external/envoy external/envoy_new > envoy/1.20/patches/envoy/$(date +%Y%m%d)-what-changed.patch
+cd external
+diff -Naur envoy envoy_new > ../envoy/1.20/patches/envoy/$(date +%Y%m%d)-what-changed.patch
 ```
 
 注意补丁执行顺序按照文件名字符顺序，请以时间戳开头


### PR DESCRIPTION
`diff -Naur external/envoy external/envoy_new > envoy/1.20/patches/envoy/$(date +%Y%m%d)-what-changed.patch`
The patch file produced by this command cannot be pathed to source code.