### PR TITLE
doc: add ai-proxy plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -41,12 +41,12 @@ Please be noted that locale switching function doesn't work if you start the web
 
 ### Add a new doc
  
-1. Add new .md file under i18n/en-us/docusaurus-plugin-content-docs/current or i18n/zh-cn/docusaurus-plugin-content-docs/current. Corresponding to Chinese file and English file , and the Chinese and English file names should be consistent.
+1. Add new .md file under i18n/en-us/docusaurus-plugin-content-docs/current or i18n/zh-cn/docusaurus-plugin-content-docs/current. Corresponding to Chinese file and English file , and the Chinese and English file names should be consistent. Due to the special reasons of the current i18n implementation, you also need to add a stub file with the same name in the [docs](./docs) directory.
 2. Update sidebar.js, add a new entry to the blog in either en-us or zh-cn.
 
 ### Add a new article for developers
 
-1. Add new .md file under i18n/en-us/docusaurus-plugin-content-docs/current/developers or i18n/zh-cn/docusaurus-plugin-content-docs/current/developers, the file name should end up with _dev.md. Note that the suffix _dev is necessary.
+1. Add new .md file under i18n/en-us/docusaurus-plugin-content-docs/current/developers or i18n/zh-cn/docusaurus-plugin-content-docs/current/developers, the file name should end up with _dev.md. Note that the suffix _dev is necessary. Due to the special reasons of the current i18n implementation, you also need to add a stub file with the same name in the [docs](./docs) directory.
 2. Update sidebar.js, add a new entry in either en-us or zh-cn.
 
 ### Add a new blog

--- a/docs/plugins/ai-proxy.md
+++ b/docs/plugins/ai-proxy.md
@@ -1,0 +1,1 @@
+Placeholder. DO NOT DELETE.

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/ai-proxy.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/ai-proxy.md
@@ -1,0 +1,535 @@
+---
+title: AI 代理
+keywords: [higress,ai,proxy,rag]
+description: AI 代理插件配置参考
+---
+
+## 功能说明
+
+`AI 代理` 插件实现了基于 OpenAI API 契约的 AI 代理功能。目前支持 OpenAI、Azure OpenAI、月之暗面（Moonshot）和通义千问等 AI
+服务提供商。
+
+## 配置字段
+
+### 基本配置
+
+| 名称         | 数据类型   | 填写要求 | 默认值 | 描述               |
+|------------|--------|------|-----|------------------|
+| `provider` | object | 必填   | -   | 配置目标 AI 服务提供商的信息 |
+
+`provider` 的配置字段说明如下：
+
+| 名称             | 数据类型            | 填写要求 | 默认值 | 描述                                                                               |
+|----------------|-----------------|------|-----|----------------------------------------------------------------------------------|
+| `type`         | string          | 必填   | -   | AI 服务提供商名称。目前支持以下取值：openai, azure, moonshot, qwen, groq, claude                  |
+| `apiTokens`    | array of string | 必填   | -   | 用于在访问 AI 服务时进行认证的令牌。如果配置了多个 token，插件会在请求时随机进行选择。部分服务提供商只支持配置一个 token。            |
+| `timeout`      | number          | 非必填  | -   | 访问 AI 服务的超时时间。单位为毫秒。默认值为 120000，即 2 分钟                                           |
+| `modelMapping` | map of string   | 非必填  | -   | AI 模型映射表，用于将请求中的模型名称映射为服务提供商支持模型名称。<br/>可以使用 "*" 为键来配置通用兜底映射关系                   |
+| `protocol`     | string          | 非必填  | -   | 插件对外提供的 API 接口契约。目前支持以下取值：openai（默认值，使用 OpenAI 的接口契约）、original（使用目标服务提供商的原始接口契约） |
+| `context`      | object          | 非必填  | -   | 配置 AI 对话上下文信息                                                                    |
+
+`context` 的配置字段说明如下：
+
+| 名称            | 数据类型   | 填写要求 | 默认值 | 描述                               |
+|---------------|--------|------|-----|----------------------------------|
+| `fileUrl`     | string | 必填   | -   | 保存 AI 对话上下文的文件 URL。仅支持纯文本类型的文件内容 |
+| `serviceName` | string | 必填   | -   | URL 所对应的 Higress 后端服务完整名称        |
+| `servicePort` | number | 必填   | -   | URL 所对应的 Higress 后端服务访问端口        |
+
+### 提供商特有配置
+
+#### OpenAI
+
+OpenAI 所对应的 `type` 为 `openai`。它并无特有的配置字段。
+
+#### Azure OpenAI
+
+Azure OpenAI 所对应的 `type` 为 `azure`。它特有的配置字段如下：
+
+| 名称                | 数据类型   | 填写要求 | 默认值 | 描述                                           |
+|-------------------|--------|------|-----|----------------------------------------------|
+| `azureServiceUrl` | string | 必填   | -   | Azure OpenAI 服务的 URL，须包含 `api-version` 查询参数。 |
+
+**注意：** Azure OpenAI 只支持配置一个 API Token。
+
+#### 月之暗面（Moonshot）
+
+月之暗面所对应的 `type` 为 `moonshot`。它特有的配置字段如下：
+
+| 名称               | 数据类型   | 填写要求 | 默认值 | 描述                                                          |
+|------------------|--------|------|-----|-------------------------------------------------------------|
+| `moonshotFileId` | string | 非必填  | -   | 通过文件接口上传至月之暗面的文件 ID，其内容将被用做 AI 对话的上下文。不可与 `context` 字段同时配置。 |
+
+#### 通义千问（Qwen）
+
+通义千问所对应的 `type` 为 `qwen`。它并无特有的配置字段。
+
+#### Groq
+
+Groq 所对应的 `type` 为 `groq`。它并无特有的配置字段。
+
+#### Claude
+
+月之暗面所对应的 `type` 为 `claude`。它特有的配置字段如下：
+
+| 名称        | 数据类型   | 填写要求 | 默认值 | 描述                |
+|-----------|--------|-----|-----|-------------------|
+| `version` | string | 必填  | -   | Claude 服务的 API 版本 |
+
+## 用法示例
+
+### 使用 OpenAI 协议代理 Azure OpenAI 服务
+
+使用最基本的 Azure OpenAI 服务，不配置任何上下文。
+
+**配置信息**
+
+```yaml
+provider:
+  type: azure
+  apiTokens:
+    - "YOUR_AZURE_OPENAI_API_TOKEN"
+  azureServiceUrl: "https://YOUR_RESOURCE_NAME.openai.azure.com/openai/deployments/YOUR_DEPLOYMENT_NAME/chat/completions?api-version=2024-02-15-preview",
+```
+
+**请求示例**
+
+```json
+{
+  "model": "gpt-3",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ],
+  "temperature": 0.3
+}
+```
+
+**响应示例**
+
+```json
+{
+  "choices": [
+    {
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        }
+      },
+      "finish_reason": "stop",
+      "index": 0,
+      "logprobs": null,
+      "message": {
+        "content": "你好！我是一个AI助手，可以回答你的问题和提供帮助。有什么我可以帮到你的吗？",
+        "role": "assistant"
+      }
+    }
+  ],
+  "created": 1714807624,
+  "id": "chatcmpl-abcdefg1234567890",
+  "model": "gpt-35-turbo-16k",
+  "object": "chat.completion",
+  "prompt_filter_results": [
+    {
+      "prompt_index": 0,
+      "content_filter_results": {
+        "hate": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "self_harm": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "sexual": {
+          "filtered": false,
+          "severity": "safe"
+        },
+        "violence": {
+          "filtered": false,
+          "severity": "safe"
+        }
+      }
+    }
+  ],
+  "system_fingerprint": null,
+  "usage": {
+    "completion_tokens": 40,
+    "prompt_tokens": 15,
+    "total_tokens": 55
+  }
+}
+```
+
+### 使用 OpenAI 协议代理通义千问服务
+
+使用通义千问服务，并配置从 OpenAI 大模型到通义千问的模型映射关系。
+
+**配置信息**
+
+```yaml
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    'gpt-3': "qwen-turbo"
+    'gpt-35-turbo': "qwen-plus"
+    'gpt-4-turbo': "qwen-max"
+    '*': "qwen-turbo"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "gpt-3",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ],
+  "temperature": 0.3
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "c2518bd3-0f46-97d1-be34-bb5777cb3108",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "我是通义千问，由阿里云开发的AI助手。我可以回答各种问题、提供信息和与用户进行对话。有什么我可以帮助你的吗？"
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "created": 1715175072,
+  "model": "qwen-turbo",
+  "object": "chat.completion",
+  "usage": {
+    "prompt_tokens": 24,
+    "completion_tokens": 33,
+    "total_tokens": 57
+  }
+}
+```
+
+### 使用通义千问配合纯文本上下文信息
+
+使用通义千问服务，同时配置纯文本上下文信息。
+
+**配置信息**
+
+```yaml
+provider:
+  type: qwen
+  apiTokens:
+    - "YOUR_QWEN_API_TOKEN"
+  modelMapping:
+    "*": "qwen-turbo"
+  context:
+    - fileUrl: "http://file.default.svc.cluster.local/ai/context.txt",
+      serviceName: "file.dns",
+      servicePort: 80
+```
+
+**请求示例**
+
+```json
+{
+  "model": "gpt-3",
+  "messages": [
+    {
+      "role": "user",
+      "content": "请概述文案内容"
+    }
+  ],
+  "temperature": 0.3
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "cmpl-77861a17681f4987ab8270dbf8001936",
+  "object": "chat.completion",
+  "created": 9756990,
+  "model": "moonshot-v1-128k",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "这份文案是一份关于..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 20181,
+    "completion_tokens": 439,
+    "total_tokens": 20620
+  }
+}
+```
+
+### 使用月之暗面配合其原生的文件上下文
+
+提前上传文件至月之暗面，以文件内容作为上下文使用其 AI 服务。
+
+**配置信息**
+
+```yaml
+provider:
+  type: moonshot
+  apiTokens:
+    - "YOUR_MOONSHOT_API_TOKEN"
+  moonshotFileId: "YOUR_MOONSHOT_FILE_ID",
+  modelMapping:
+    '*': "moonshot-v1-32k"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "gpt-4-turbo",
+  "messages": [
+    {
+      "role": "user",
+      "content": "请概述文案内容"
+    }
+  ],
+  "temperature": 0.3
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "cmpl-e5ca873642ca4f5d8b178c1742f9a8e8",
+  "object": "chat.completion",
+  "created": 1872961,
+  "model": "moonshot-v1-128k",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "文案内容是关于一个名为“xxxx”的支付平台..."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 11,
+    "completion_tokens": 498,
+    "total_tokens": 509
+  }
+}
+```
+
+### 使用 OpenAI 协议代理 Groq 服务
+
+**配置信息**
+
+```yaml
+provider:
+  type: groq
+  apiTokens:
+    - "YOUR_GROQ_API_TOKEN"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "llama3-8b-8192",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ]
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "chatcmpl-26733989-6c52-4056-b7a9-5da791bd7102",
+  "object": "chat.completion",
+  "created": 1715917967,
+  "model": "llama3-8b-8192",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "😊 Ni Hao! (That's \"hello\" in Chinese!)\n\nI am LLaMA, an AI assistant developed by Meta AI that can understand and respond to human input in a conversational manner. I'm not a human, but a computer program designed to simulate conversations and answer questions to the best of my ability. I'm happy to chat with you in Chinese or help with any questions or topics you'd like to discuss! 😊"
+      },
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 16,
+    "prompt_time": 0.005,
+    "completion_tokens": 89,
+    "completion_time": 0.104,
+    "total_tokens": 105,
+    "total_time": 0.109
+  },
+  "system_fingerprint": "fp_dadc9d6142",
+  "x_groq": {
+    "id": "req_01hy2awmcxfpwbq56qh6svm7qz"
+  }
+}
+```
+
+### 使用 OpenAI 协议代理 Claude 服务
+
+**配置信息**
+
+```yaml
+provider:
+  type: claude
+  apiTokens:
+    - "YOUR_CLAUDE_API_TOKEN"
+```
+
+**请求示例**
+
+```json
+{
+  "model": "claude-3-opus-20240229",
+  "max_tokens": 1024,
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ]
+}
+```
+
+**响应示例**
+
+```json
+{
+  "id": "msg_01K8iLH18FGN7Xd9deurwtoD",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-3-opus-20240229",
+  "stop_sequence": null,
+  "usage": {
+    "input_tokens": 16,
+    "output_tokens": 141
+  },
+  "content": [
+    {
+      "type": "text",
+      "text": "你好!我是Claude,一个由Anthropic公司开发的人工智能助手。我的任务是尽我所能帮助人类,比如回答问题,提供建议和意见,协助完成任务等。我掌握了很多知识,也具备一定的分析和推理能力,但我不是人类,也没有实体的身体。很高兴认识你!如果有什么需要帮助的地方,欢迎随时告诉我。"
+    }
+  ],
+  "stop_reason": "end_turn"
+}
+```
+
+## 完整配置示例
+
+以下以使用 OpenAI 协议代理 Groq 服务为例，展示完整的插件配置示例。构建 ai-proxy 的 wasm 镜像的步骤可以参考[这里](../plugins/custom#构建-wasm-镜像)。
+
+```yaml
+apiVersion: extensions.higress.io/v1alpha1
+kind: WasmPlugin
+metadata:
+  name: ai-proxy-groq
+  namespace: higress-system
+spec:
+  matchRules:
+  - config:
+      provider:
+        type: groq
+        apiTokens: 
+          - "YOUR_API_TOKEN"
+    ingress:
+    - groq
+  url: oci://<YOUR-WASM-IMAGE>
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    higress.io/backend-protocol: HTTPS
+    higress.io/destination: groq.dns
+    higress.io/proxy-ssl-name: api.groq.com
+    higress.io/proxy-ssl-server-name: "on"
+  labels:
+    higress.io/resource-definer: higress
+  name: groq
+  namespace: higress-system
+spec:
+  ingressClassName: higress
+  rules:
+  - host: <YOUR-DOMAIN> 
+    http:
+      paths:
+      - backend:
+          resource:
+            apiGroup: networking.higress.io
+            kind: McpBridge
+            name: default
+        path: /
+        pathType: Prefix
+---
+apiVersion: networking.higress.io/v1
+kind: McpBridge
+metadata:
+  name: default
+  namespace: higress-system
+spec:
+  registries:
+  - domain: api.groq.com
+    name: groq
+    port: 443
+    type: dns
+```
+
+访问示例：
+
+```json
+curl "http://<YOUR-DOMAIN>/v1/chat/completions" -H "Content-Type: application/json" -d '{
+  "model": "llama3-8b-8192",
+  "messages": [
+    {
+      "role": "user",
+      "content": "你好，你是谁？"
+    }
+  ]
+}'
+```

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/ai-proxy.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/plugins/ai-proxy.md
@@ -522,7 +522,7 @@ spec:
 
 访问示例：
 
-```json
+```bash
 curl "http://<YOUR-DOMAIN>/v1/chat/completions" -H "Content-Type: application/json" -d '{
   "model": "llama3-8b-8192",
   "messages": [

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,7 +34,7 @@ const sidebars = {
         {
           type: 'category',
           label: 'Plugins',
-          items: ['plugins/intro', 'plugins/ai-proxy', 'plugins/custom', 'plugins/jwt-auth', 'plugins/hmac-auth', 'plugins/key-auth', 'plugins/basic-auth', 'plugins/key-rate-limit', 'plugins/custom-response', 'plugins/bot-detect', 'plugins/request-block', 'plugins/waf'],
+          items: ['plugins/intro', 'plugins/custom', 'plugins/ai-proxy', 'plugins/jwt-auth', 'plugins/hmac-auth', 'plugins/key-auth', 'plugins/basic-auth', 'plugins/key-rate-limit', 'plugins/custom-response', 'plugins/bot-detect', 'plugins/request-block', 'plugins/waf'],
         },
         {
           type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,7 +34,7 @@ const sidebars = {
         {
           type: 'category',
           label: 'Plugins',
-          items: ['plugins/intro', 'plugins/custom', 'plugins/jwt-auth', 'plugins/hmac-auth', 'plugins/key-auth', 'plugins/basic-auth', 'plugins/key-rate-limit', 'plugins/custom-response', 'plugins/bot-detect', 'plugins/request-block', 'plugins/waf'],
+          items: ['plugins/intro', 'plugins/ai-proxy', 'plugins/custom', 'plugins/jwt-auth', 'plugins/hmac-auth', 'plugins/key-auth', 'plugins/basic-auth', 'plugins/key-rate-limit', 'plugins/custom-response', 'plugins/bot-detect', 'plugins/request-block', 'plugins/waf'],
         },
         {
           type: 'category',


### PR DESCRIPTION
内容来自 ai-proxy 插件的 [README 文档](https://github.com/alibaba/higress/blob/main/plugins/wasm-go/extensions/ai-proxy/README.md), 在此基础上补充了 groq, claude 插件的文档，并在最后添加了完整的配置示例。

groq PR: https://github.com/alibaba/higress/pull/967
claude PR: https://github.com/alibaba/higress/pull/969
