### PR TITLE
correct the Markdown format in the documentation.

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,7 +106,7 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
-      metadata: [{ name: 'keywords', content: 'higress,higress官网,云原生网关' }],
+      metadata: [{ name: 'keywords', content: 'higress,higress官网,云原生网关' }, {name:'baidu-site-verification', content: 'codeva-T2MeTQHYnM'}],
       // Replace with your project's social card
       image: 'img/higress_logo_small.png',
       colorMode: {

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/developers/developers_dev.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/developers/developers_dev.md
@@ -68,7 +68,7 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 - 贡献代码（包含文档）DIFF 行数（包含增删）达到 500+
 
-> 不仅只有贡献代码，在Higress官网仓库(https://github.com/higress-group/higress-group.github.io)贡献文档，也可以满足此要求
+> 不仅只有贡献代码，在Higress官网仓库(https://github.com/higress-group/higress-group.github.io) 贡献文档，也可以满足此要求
 
 - 在社区周会进行 1 次主题分享
 


### PR DESCRIPTION
I noticed some display issues in the documentation, so I've adjusted the Markdown format accordingly.

<img width="1035" alt="image" src="https://github.com/user-attachments/assets/0679542b-82a8-4cad-8bf2-e704a0d013b4">
