### PR TITLE
correct the Markdown format in the documentation. 

### DIFF
--- a/src/content/docs/developers/zh-cn/developers_dev.md
+++ b/src/content/docs/developers/zh-cn/developers_dev.md
@@ -68,7 +68,7 @@ description: Higress 维护者名单
 
 - 贡献代码（包含文档）DIFF 行数（包含增删）达到 500+
 
-> 不仅只有贡献代码，在Higress官网仓库(https://github.com/higress-group/higress-group.github.io) 贡献文档，也可以满足此要求
+> 不仅只有贡献代码，在Higress官网仓库（[https://github.com/higress-group/higress-group.github.io](https://github.com/higress-group/higress-group.github.io)）贡献文档，也可以满足此要求
 
 - 在社区周会进行 1 次主题分享
 

--- a/src/content/docs/developers/zh-cn/developers_dev.md
+++ b/src/content/docs/developers/zh-cn/developers_dev.md
@@ -68,7 +68,7 @@ description: Higress 维护者名单
 
 - 贡献代码（包含文档）DIFF 行数（包含增删）达到 500+
 
-> 不仅只有贡献代码，在Higress官网仓库(https://github.com/higress-group/higress-group.github.io)贡献文档，也可以满足此要求
+> 不仅只有贡献代码，在Higress官网仓库(https://github.com/higress-group/higress-group.github.io) 贡献文档，也可以满足此要求
 
 - 在社区周会进行 1 次主题分享
 


### PR DESCRIPTION
I noticed some display issues in the documentation, so I've adjusted the Markdown format accordingly.
<img width="1028" alt="368274702-4c310dff-cd7e-447d-9a37-c8ae4323747b" src="https://github.com/user-attachments/assets/879ee750-b9e4-4c93-beaa-edca3511e3b6">
