### PR TITLE
fix: Use x-scope instead of scope as field name in Wasm spec

### DIFF
--- a/src/content/docs/latest/en/user/wasm-image-spec.md
+++ b/src/content/docs/latest/en/user/wasm-image-spec.md
@@ -60,7 +60,7 @@ spec:
       properties:
         consumers:
           type: array
-          scope: GLOBAL # Field effective scope. Options: GLOBAL (global configuration), INSTANCE (instance-level configuration, which can be set associated to routes or domains.), ALL (Available as both global and instance-level configurations). Optional. Default value is INSTANCE.
+          x-scope: GLOBAL # Field effective scope. Options: GLOBAL (global configuration), INSTANCE (instance-level configuration, which can be set associated to routes or domains.), ALL (Available as both global and instance-level configurations). Optional. Default value is INSTANCE.
           title: 调用方列表
           x-title-i18n:
             en-US: Consumer List

--- a/src/content/docs/latest/en/user/wasm-image-spec.md
+++ b/src/content/docs/latest/en/user/wasm-image-spec.md
@@ -60,7 +60,7 @@ spec:
       properties:
         consumers:
           type: array
-          x-scope: GLOBAL # Field effective scope. Options: GLOBAL (global configuration), INSTANCE (instance-level configuration, which can be set associated to routes or domains.), ALL (Available as both global and instance-level configurations). Optional. Default value is INSTANCE.
+          x-scope: GLOBAL # Field effective scope. Options: GLOBAL (global configuration), INSTANCE (instance-level configuration, which can be set associated to routes, domains or services.), ALL (Available as both global and instance-level configurations). Optional. Default value is INSTANCE.
           title: 调用方列表
           x-title-i18n:
             en-US: Consumer List

--- a/src/content/docs/latest/zh-cn/user/wasm-image-spec.md
+++ b/src/content/docs/latest/zh-cn/user/wasm-image-spec.md
@@ -65,7 +65,7 @@ spec:
       properties:
         consumers:
           type: array
-          scope: GLOBAL # 配置项作用范围。可选值：GLOBAL（全局配置）、INSTANCE（实例级配置，即在关联路由、域名时的配置）、ALL（全局、实例皆可配置）。可空。缺省值为 INSTANCE。
+          x-scope: GLOBAL # 配置项作用范围。可选值：GLOBAL（全局配置）、INSTANCE（实例级配置，即在关联路由、域名时的配置）、ALL（全局、实例皆可配置）。可空。缺省值为 INSTANCE。
           title: 调用方列表
           x-title-i18n:
             en-US: Consumer List

--- a/src/content/docs/latest/zh-cn/user/wasm-image-spec.md
+++ b/src/content/docs/latest/zh-cn/user/wasm-image-spec.md
@@ -65,7 +65,7 @@ spec:
       properties:
         consumers:
           type: array
-          x-scope: GLOBAL # 配置项作用范围。可选值：GLOBAL（全局配置）、INSTANCE（实例级配置，即在关联路由、域名时的配置）、ALL（全局、实例皆可配置）。可空。缺省值为 INSTANCE。
+          x-scope: GLOBAL # 配置项作用范围。可选值：GLOBAL（全局配置）、INSTANCE（实例级配置，即在关联路由、域名、服务时的配置）、ALL（全局、实例皆可配置）。可空。缺省值为 INSTANCE。
           title: 调用方列表
           x-title-i18n:
             en-US: Consumer List


### PR DESCRIPTION
According to OpenAPI extensions documentation, custom fields need use names started with "x-".

https://swagger.io/docs/specification/v3_0/openapi-extensions/
![image](https://github.com/user-attachments/assets/6c0854cd-84bb-4f87-927c-7aba73d7124e)
