### PR TITLE
feat: Add gateway ports properties to helm values documents

### DIFF
--- a/src/content/docs/latest/en/ops/deploy-by-helm.md
+++ b/src/content/docs/latest/en/ops/deploy-by-helm.md
@@ -37,8 +37,8 @@ helm install higress higress.io/higress -n higress-system --create-namespace
 | **Core Paramters** |  |  |
 | higress-core.gateway.replicas | Number of Higress Gateway pods | 2 |
 | higress-core.controller.replicas | Number of Higress Controller pods | 1 |
-| global.o11y.enabled | If `true`, o11y suite (Grafana + Promethues) will be installed. | false |
-| global.pvc.rwxSupported | Set to `false` when installing to a standard K8s cluster and the target cluster doesn't support the ReadWriteMany access mode of PersistentVolumeClaim. | true |
+| higress-core.gateway.httpPort | HTTP port to be listened by Higress Gateway | 80 |
+| higress-core.gateway.httpsPort | HTTPS port to be listened by Higress Gateway | 443 |
 | **Console Paramters** |  |  |
 | higress-console.replicaCount | Number of Higress Console pods | 1 |
 | higress-console.service.type | K8s service type used by Higress Console | ClusterIP |

--- a/src/content/docs/latest/zh-cn/ops/deploy-by-helm.md
+++ b/src/content/docs/latest/zh-cn/ops/deploy-by-helm.md
@@ -39,6 +39,8 @@ helm install higress higress.io/higress -n higress-system --create-namespace
 | global.pvc.rwxSupported | 标识目标 K8s 集群是否支持 PersistentVolumeClaim 的 ReadWriteMany 操作方式。 | true |
 | **核心组件参数** |  |  |
 | higress-core.gateway.replicas | Higress Gateway 的 pod 数量 | 2 |
+| higress-core.gateway.httpPort | Higress Gateway 将监听的 HTTP 端口。| 80 |
+| higress-core.gateway.httpsPort | Higress Gateway 将监听的 HTTPS 端口。| 443 |
 | higress-core.controller.replicas | Higress Controller 的 pod 数量 | 1 |
 | **控制台参数** |  |  |
 | higress-console.replicaCount | Higress Console 的 pod 数量 | 1 |

--- a/src/content/docs/latest/zh-cn/user/configurations.md
+++ b/src/content/docs/latest/zh-cn/user/configurations.md
@@ -43,6 +43,8 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 | higress-core.gateway.serviceAccount.annotations                | 指定需要添加到 ServiceAccount 上的注释。                                                              | {}                  |
 | higress-core.gateway.serviceAccount.name                       | 指定要使用的 ServiceAccount 的名称。                                                                | ""                  |
 | higress-core.gateway.env	                                      | 指定 Gateway 使用的环境变量。                                                                       | {}                  |
+| higress-core.gateway.httpPort	                                 | Higress Gateway 将监听的 HTTP 端口。                                                                 | 80                   |
+| higress-core.gateway.httpsPort                                 | Higress Gateway 将监听的 HTTPS 端口。                                                                 | 443                   |
 | higress-core.gateway.hostNetwork	                              | 指定是否使用宿主机网络。                                                                              | false               |
 | higress-core.gateway.labels	                                   | 指定应用于所有 gateway 资源的标签。                                                                    | {}                  |
 | higress-core.gateway.annotations	                              | 指定要应用于所有 gateway 资源的注释。                                                                   | {}                  |


### PR DESCRIPTION
在低版本内核不便于配置权限的情况下，用户也可以通过修改监听端口来绕过非root不得监听小于1024的端口的问题。