### PR TITLE
fix: aliyun computenest image links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-
 # environment variables
 .env
 .env.production
@@ -24,3 +23,6 @@ pnpm-debug.log*
 
 build
 .docusaurus
+
+.idea
+.vscode

--- a/src/content/docs/latest/en/ops/deploy-by-aliyun-computenest.md
+++ b/src/content/docs/latest/en/ops/deploy-by-aliyun-computenest.md
@@ -20,16 +20,16 @@ Through Aliyun ComputeNest, a one-click deployment solution for Higress is provi
 
 - According to the interface prompt, fill in the parameters to complete the deployment.
   Select a resource type and configure an ECS instance password..
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img1.jpg)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img1.jpg)
   Configure the Nacos service. If you do not have an independently deployed Nacos service, you can use the built-in Nacos service.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img2.jpg)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img2.jpg)
   If the Nacos service is deployed independently, set the IP address of the Nacos service. If authentication is enabled for Nacos, enter the username and password.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img3.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img3.png)
   Finally, configure the zone. You can create a new VPC or use an existing VPC.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img4.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img4.png)
 - After the service instance is created, go to the service instance details page. On the Overview page, you can obtain the login information of the Higress.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img5.png)
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img6.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img5.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img6.png)
 
 
 

--- a/src/content/docs/latest/zh-cn/ops/deploy-by-aliyun-computenest.md
+++ b/src/content/docs/latest/zh-cn/ops/deploy-by-aliyun-computenest.md
@@ -20,16 +20,16 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 - 部署页面中，根据界面提示，填写配置参数并提交订单。
   选择资源类型并配置ECS实例密码.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img1.jpg)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img1.jpg)
   配置Nacos服务，如果没有独立部署的Nacos服务，可以使用内置的Nacos服务，但不建议生产环境下使用
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img2.jpg)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img2.jpg)
   若有独立部署的Nacos服务，设置Nacos服务的Ip地址，如果Nacos开启了鉴权认证，则需要填写用户名和密码
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img3.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img3.png)
   最后配置可用区，可选择新建VPC，也可使用已有的VPC.
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img4.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img4.png)
 - 等到服务实例部署成功, 进入服务实例详情页，获取Higress的登录信息。
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img5.png)
-  ![image](https://github.com/aliyun-computenest/quickstart-higress/blob/main/docs/img6.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img5.png)
+  ![image](https://raw.githubusercontent.com/aliyun-computenest/quickstart-higress/main/docs/img6.png)
 
 
 


### PR DESCRIPTION
图片显示异常，GitHub 仓库中的图片链接应使用以 raw.githubusercontent.com 开头的链接。

![CleanShot 2024-12-05 at 20 05 54@2x](https://github.com/user-attachments/assets/266c6209-eaa8-4cde-b98b-c56b114ec7dd)
