### PR TITLE
fix: Fix incorrect code section display styles

### DIFF
--- a/src/content/blog/higress-code.md
+++ b/src/content/blog/higress-code.md
@@ -195,7 +195,7 @@ s.server.RunComponent(func(stop <-chan struct{}) error {
 
 #### 在ready服务记录表里注册xds服务
 
-```gog
+```go
 s.readinessProbes["xds"] = func() (bool, error) {
     return s.xdsServer.IsServerReady(), nil
 }

--- a/src/content/blog/skywalking.md
+++ b/src/content/blog/skywalking.md
@@ -114,7 +114,7 @@ Higress是基于阿里内部的Envoy Gateway实践沉淀、以开源 Istio + Env
 业务应用通过与 [go2sky](https://github.com/SkyAPM/go2sky) 项目集成 SkyWalking 监控 Golang 应用程序，主要通过 Gin middleware 和 Http 请求手动埋点。
 
 1、集成 Gin middleware
-```golang
+```go
 func middleware(engine *gin.Engine, tracer *go2sky.Tracer) gin.HandlerFunc {
 	if engine == nil || tracer == nil {
 		return func(c *gin.Context) {
@@ -158,7 +158,7 @@ func getOperationName(c *gin.Context) string {
 
 2、Http请求手动埋点
 
-```golang
+```go
 func traceHttpCall(c *gin.Context, req *http.Request, url string, fn func(req *http.Request) (*http.Response, error)) (*http.Response, error) {
 	tracer := go2sky.GetGlobalTracer()
 	if tracer == nil {
@@ -302,8 +302,8 @@ data:
       sampling: 100
       timeout: 500
       skywalking:
-       service: skywalking-oap-server.op-system.svc.cluster.local
-       port: 11800
+        service: skywalking-oap-server.op-system.svc.cluster.local
+        port: 11800
 ```
 
 ## 七、Skywalking 链路跟踪

--- a/src/content/docs/ebook/en/wasm14.md
+++ b/src/content/docs/ebook/en/wasm14.md
@@ -332,7 +332,7 @@ go get github.com/tidwall/gjson
 #### 4.2.2 编写 main.go 文件
 首先，我们编写 easy-logger 插件的基本框架，暂时只读取我们设置的配置参数，不在请求和响应阶段进行任何处理。
 
-```golang
+```go
 package main
 
 import (
@@ -762,7 +762,7 @@ curl -X POST -v http://127.0.0.1:10000/hello \
 
 接下来，我们将通过自定义函数来处理请求和响应信息。通过设置插件参数，我们可以控制是否打印请求和响应信息，并根据指定的响应状态码决定是否记录响应内容。
 
-```golang
+```go
 package main
 
 import (

--- a/src/content/docs/ebook/en/wasm15.md
+++ b/src/content/docs/ebook/en/wasm15.md
@@ -666,7 +666,7 @@ TinyGo 允许禁用 GC，但由于内部需要使用映射（隐式引起分配�
 
 用 Proxy-Wasm Go SDK 实现一个简单的插件，具体样例如下：
 
-```golang
+```go
 package main
 
 import (

--- a/src/content/docs/ebook/en/wasm16.md
+++ b/src/content/docs/ebook/en/wasm16.md
@@ -41,7 +41,7 @@ Higress 插件 Go SDK 主要增强功能如下：
 
 相对应于 proxy-wasm-go-sdk 中的 VMContext、PluginContext、HttpContext 3 个上下文， 在 Higress 插件 Go SDK 中是 CommonVmCtx、CommonPluginCtx、CommonHttpCtx 3 个支持泛型的 struct。 3 个 struct 的核心内容如下：
 
-```golang
+```go
 type CommonVmCtx[PluginConfig any] struct {
     // proxy-wasm-go-sdk DefaultVMContext 默认实现
     types.DefaultVMContext
@@ -106,7 +106,7 @@ type CommonHttpCtx[PluginConfig any] struct {
 
 ### 2.1 启动入口和 VM 上下文（CommonVmCtx）
 
-```golang
+```go
 func main() {
 	wrapper.SetCtx(
 		// 插件名称
@@ -138,7 +138,7 @@ func main() {
 - 创建 CommonVmCtx 对象同时设置自定义插件回调钩子函数。
 - 然后再调用 proxywasm.SetVMContext 设置 VMContext。
 
-```golang
+```go
 func SetCtx[PluginConfig any](pluginName string, setFuncs ...SetPluginFunc[PluginConfig]) {
 	// 调用 proxywasm.SetVMContext 设置 VMContext
 	proxywasm.SetVMContext(NewCommonVmCtx(pluginName, setFuncs...))
@@ -162,7 +162,7 @@ func NewCommonVmCtx[PluginConfig any](pluginName string, setFuncs ...SetPluginFu
 
 #### 2.2.1 创建 CommonPluginCtx 对象
 通过 CommonVmCtx 的 NewPluginContext 方法创建 CommonPluginCtx 对象， 设置 CommonPluginCtx 的 vm 引用。
-```golang
+```go
 func (ctx *CommonVmCtx[PluginConfig]) NewPluginContext(uint32) types.PluginContext {
 	return &CommonPluginCtx[PluginConfig]{
 		vm: ctx,
@@ -173,7 +173,7 @@ func (ctx *CommonVmCtx[PluginConfig]) NewPluginContext(uint32) types.PluginConte
 #### 2.2.2 插件启动和插件配置解析
 
 CommonPluginCtx 的 OnPluginStart 部分核心代码如下：
-```golang
+```go
 func (ctx *CommonPluginCtx[PluginConfig]) OnPluginStart(int) types.OnPluginStartStatus {
 	// 调用 proxywasm.GetPluginConfiguration 获取插件配置
 	data, err := proxywasm.GetPluginConfiguration()
@@ -245,7 +245,7 @@ spec:
 
 可以看出 matchRule 下 config 配置内容和 defaultConfig 配置内容不一样。所以在开发插件的时候，需要同时设置 parseConfig 和 parseRuleConfig 两个回调钩子函数。
 baisc-auth 部分核心代码如下：
-```golang
+```go
 func main() {
 	wrapper.SetCtx(
 		"basic-auth",
@@ -309,7 +309,7 @@ func parseOverrideRuleConfig(json gjson.Result, global BasicAuthConfig, config *
 
 CommonPluginCtx 的 NewHttpContext 部分核心代码如下：
 
-```golang
+```go
 func (ctx *CommonPluginCtx[PluginConfig]) NewHttpContext(contextID uint32) types.HttpContext {
 	httpCtx := &CommonHttpCtx[PluginConfig]{
 		plugin:      ctx,
@@ -336,7 +336,7 @@ func (ctx *CommonPluginCtx[PluginConfig]) NewHttpContext(contextID uint32) types
 #### 2.3.2 OnHttpRequestHeaders
 
 OnHttpRequestHeaders 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	// 获取当前 HTTP 请求生效插件配置
 	config, err := ctx.plugin.GetMatchConfig()
@@ -365,7 +365,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, end
 #### 2.3.3 OnHttpRequestBody
 
 OnHttpRequestBody 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
 	...
 	// 如果不需要处理请求 body，则直接返回，继续后续处理
@@ -404,7 +404,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestBody(bodySize int, endOfStr
 #### 2.3.4 OnHttpResponseHeaders
 
 OnHttpResponseHeaders 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
 	...
 	// To avoid unexpected operations, plugins do not read the binary content body
@@ -423,7 +423,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseHeaders(numHeaders int, en
 #### 2.3.5 OnHttpResponseBody
 
 OnHttpResponseBody 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseBody(bodySize int, endOfStream bool) types.Action {
     ...
 	// 如果不需要处理响应 body，则直接返回，继续后续处理
@@ -461,7 +461,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseBody(bodySize int, endOfSt
 #### 2.3.6 OnHttpStreamDone
 
 OnHttpStreamDone 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpStreamDone() {
 	...
 	ctx.plugin.vm.onHttpStreamDone(ctx, *ctx.config, ctx.plugin.vm.log)
@@ -473,7 +473,7 @@ OnHttpStreamDone 比较简单，自定义插件有 onHttpStreamDone 回调钩子
 #### 2.3.7 CommonHttpCtx 方法
 
 CommonHttpCtx 提供以下方法，自定义插件可以调用，其代码和注释如下：
-```golang
+```go
 // 设置自定义上下文，这个上下文可以在自定义插件所有回调钩子函数中可以获取
 func (ctx *CommonHttpCtx[PluginConfig]) SetContext(key string, value interface{}) {
 	ctx.userContext[key] = value

--- a/src/content/docs/ebook/en/wasm17.md
+++ b/src/content/docs/ebook/en/wasm17.md
@@ -12,7 +12,7 @@ keywords: [Higress]
 Higress 插件的 Go SDK 在进行 HTTP 和 Redis 调用时，是通过指定的集群名称来识别并连接到相应的 Envoy 集群。 此外，Higress 利用 [McpBridge](https://higress.cn/docs/latest/user/mcp-bridge/) 支持多种服务发现机制，包括静态配置（static）、DNS、Kubernetes 服务、Eureka、Consul、Nacos、以及 Zookeeper 等。
 每种服务发现机制对应的集群名称生成规则都有所不同，这些规则在 cluster_wrapper.go 代码文件中有所体现。
 为了包装不同的服务发现机制，Higress 插件 Go SDK 定义了 Cluster 接口，该接口包含两个方法：ClusterName 和 HostName。
-```golang
+```go
 type Cluster interface {
     // 返回 Envoy 集群名称
     ClusterName() string
@@ -22,7 +22,7 @@ type Cluster interface {
 ```
 
 ### 1.1 静态配置（static）
-```golang
+```go
 type StaticIpCluster struct {
 	ServiceName string
 	Port        int64
@@ -33,7 +33,7 @@ type StaticIpCluster struct {
 - HostName 规则为：默认为  <service_name>。
 
 ### 1.2 DNS 配置（dns）
-```golang
+```go
 type DnsCluster struct {
 	ServiceName string
 	Domain      string
@@ -45,7 +45,7 @@ type DnsCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回<Domain>。
 
 ### 1.3 Kubernetes 服务（kubernetes）
-```golang
+```go
 
 type K8sCluster struct {
 	ServiceName string
@@ -59,7 +59,7 @@ type K8sCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回 <ServiceName>.<Namespace>.svc.cluster.local。
 
 ### 1.4 Nacos
-```golang
+```go
 
 type NacosCluster struct {
 	ServiceName string
@@ -77,7 +77,7 @@ type NacosCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回 <service_name>。
 
 ### 1.5 Consul
-```golang
+```go
 type ConsulCluster struct {
 	ServiceName string
 	Datacenter  string
@@ -90,7 +90,7 @@ type ConsulCluster struct {
 
 ### 1.6 FQDN
 
-```golang
+```go
 
 type FQDNCluster struct {
 	FQDN string
@@ -103,7 +103,7 @@ type FQDNCluster struct {
 
 ## 2 HTTP 调用
 http_wrapper.go 部分核心代码如下：
-```golang
+```go
 // 回调函数
 type ResponseCallback func(statusCode int, responseHeaders http.Header, responseBody []byte)
 
@@ -128,7 +128,7 @@ type ClusterClient[C Cluster] struct {
 ```
 ClusterClient Get、Head、Options、Post、PUT、Patch、Delete、Connect、Trace、Call 方法最后调用 HttpCall 方法，其核心代码如下：
 
-```golang
+```go
 func HttpCall(cluster Cluster, method, path string, headers [][2]string, body []byte,
 	callback ResponseCallback, timeoutMillisecond ...uint32) error {
 	
@@ -185,7 +185,7 @@ Token Server 提供 2 个接口：
 
 ### 3.1 插件部分核心代码
 
-```golang
+```go
 package main
 ...
 

--- a/src/content/docs/ebook/en/wasm18.md
+++ b/src/content/docs/ebook/en/wasm18.md
@@ -266,7 +266,7 @@ envoy.yaml 配置文件增加了 `outbound|6379||redis.static` 集群，用于�
 ### 3.1 插件配置和配置解析
 
 插件配置和配置解析部分核心代码如下：
-```golang
+```go
 // LimitConfig 定义了限流插件的配置结构。
 type LimitConfig struct {
 	Keys                 []string            `yaml:"keys"`                    // 定义了用于提取限流信息的HTTP请求头字段名称。
@@ -445,7 +445,7 @@ Lua 脚本是在 Redis 中执行的，用于实现令牌桶限流算法。下面
 
 限流主要实现在插件 `onHttpRequestHeaders` 方法中，部分核心代码如下：
 
-```golang
+```go
 // onHttpRequestHeaders 函数在处理 HTTP 请求头时被调用，用于执行限流逻辑。
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config LimitConfig, log wrapper.Log) types.Action {
 	log.Debugf("onHttpRequestHeaders()")

--- a/src/content/docs/ebook/en/wasm19.md
+++ b/src/content/docs/ebook/en/wasm19.md
@@ -105,7 +105,7 @@ spec:
 - `_match_service_`：匹配服务生效，填写服务即可，支持通配符。
 
 Higress Controller 控制面转换代码逻辑在 `pkg/ingress/config/ingress_config.go` 文件的 `convertIstioWasmPlugin` func 中实现，其实现代码逻辑比较简单。
-```golang
+```go
 func (m *IngressConfig) convertIstioWasmPlugin(obj *higressext.WasmPlugin) (*extensions.WasmPlugin, error) {
 	...
 }
@@ -113,7 +113,7 @@ func (m *IngressConfig) convertIstioWasmPlugin(obj *higressext.WasmPlugin) (*ext
 
 同时在第`十六章 Higress 插件 Go SDK 与处理流程`中介绍 `CommonPluginCtx` 插件上下文在插件启动时候解析全局/路由/域名/服务级配置，其代码逻辑在 `plugins/wasm-go/pkg/matcher/rule_matcher.go` 文件的 `ParseRuleConfig` func 中实现。
 
-```golang
+```go
 func (m *RuleMatcher[PluginConfig]) ParseRuleConfig(config gjson.Result,
 	parsePluginConfig func(gjson.Result, *PluginConfig) error,
 	parseOverrideConfig func(gjson.Result, PluginConfig, *PluginConfig) error) error {
@@ -121,7 +121,7 @@ func (m *RuleMatcher[PluginConfig]) ParseRuleConfig(config gjson.Result,
 }
 ```
 另外在插件 `OnHttpRequestHeaders` 阶段根据当前请求的 `:authority`、`route_name`、`cluster_name` 获取对应的域名、路由、服务级和全局插件配置。其代码逻辑在 `plugins/wasm-go/pkg/matcher/rule_matcher.go` 文件的 `GetMatchConfig` func 中实现。
-```golang
+```go
 func (m RuleMatcher[PluginConfig]) GetMatchConfig() (*PluginConfig, error) {
 	host, err := proxywasm.GetHttpRequestHeader(":authority")
 	...

--- a/src/content/docs/ebook/zh-cn/wasm14.md
+++ b/src/content/docs/ebook/zh-cn/wasm14.md
@@ -332,7 +332,7 @@ go get github.com/tidwall/gjson
 #### 4.2.2 编写 main.go 文件
 首先，我们编写 easy-logger 插件的基本框架，暂时只读取我们设置的配置参数，不在请求和响应阶段进行任何处理。
 
-```golang
+```go
 package main
 
 import (
@@ -762,7 +762,7 @@ curl -X POST -v http://127.0.0.1:10000/hello \
 
 接下来，我们将通过自定义函数来处理请求和响应信息。通过设置插件参数，我们可以控制是否打印请求和响应信息，并根据指定的响应状态码决定是否记录响应内容。
 
-```golang
+```go
 package main
 
 import (

--- a/src/content/docs/ebook/zh-cn/wasm15.md
+++ b/src/content/docs/ebook/zh-cn/wasm15.md
@@ -666,7 +666,7 @@ TinyGo 允许禁用 GC，但由于内部需要使用映射（隐式引起分配�
 
 用 Proxy-Wasm Go SDK 实现一个简单的插件，具体样例如下：
 
-```golang
+```go
 package main
 
 import (

--- a/src/content/docs/ebook/zh-cn/wasm16.md
+++ b/src/content/docs/ebook/zh-cn/wasm16.md
@@ -41,7 +41,7 @@ Higress 插件 Go SDK 主要增强功能如下：
 
 相对应于 proxy-wasm-go-sdk 中的 VMContext、PluginContext、HttpContext 3 个上下文， 在 Higress 插件 Go SDK 中是 CommonVmCtx、CommonPluginCtx、CommonHttpCtx 3 个支持泛型的 struct。 3 个 struct 的核心内容如下：
 
-```golang
+```go
 type CommonVmCtx[PluginConfig any] struct {
     // proxy-wasm-go-sdk DefaultVMContext 默认实现
     types.DefaultVMContext
@@ -106,7 +106,7 @@ type CommonHttpCtx[PluginConfig any] struct {
 
 ### 2.1 启动入口和 VM 上下文（CommonVmCtx）
 
-```golang
+```go
 func main() {
 	wrapper.SetCtx(
 		// 插件名称
@@ -138,7 +138,7 @@ func main() {
 - 创建 CommonVmCtx 对象同时设置自定义插件回调钩子函数。
 - 然后再调用 proxywasm.SetVMContext 设置 VMContext。
 
-```golang
+```go
 func SetCtx[PluginConfig any](pluginName string, setFuncs ...SetPluginFunc[PluginConfig]) {
 	// 调用 proxywasm.SetVMContext 设置 VMContext
 	proxywasm.SetVMContext(NewCommonVmCtx(pluginName, setFuncs...))
@@ -162,7 +162,7 @@ func NewCommonVmCtx[PluginConfig any](pluginName string, setFuncs ...SetPluginFu
 
 #### 2.2.1 创建 CommonPluginCtx 对象
 通过 CommonVmCtx 的 NewPluginContext 方法创建 CommonPluginCtx 对象， 设置 CommonPluginCtx 的 vm 引用。
-```golang
+```go
 func (ctx *CommonVmCtx[PluginConfig]) NewPluginContext(uint32) types.PluginContext {
 	return &CommonPluginCtx[PluginConfig]{
 		vm: ctx,
@@ -173,7 +173,7 @@ func (ctx *CommonVmCtx[PluginConfig]) NewPluginContext(uint32) types.PluginConte
 #### 2.2.2 插件启动和插件配置解析
 
 CommonPluginCtx 的 OnPluginStart 部分核心代码如下：
-```golang
+```go
 func (ctx *CommonPluginCtx[PluginConfig]) OnPluginStart(int) types.OnPluginStartStatus {
 	// 调用 proxywasm.GetPluginConfiguration 获取插件配置
 	data, err := proxywasm.GetPluginConfiguration()
@@ -245,7 +245,7 @@ spec:
 
 可以看出 matchRule 下 config 配置内容和 defaultConfig 配置内容不一样。所以在开发插件的时候，需要同时设置 parseConfig 和 parseRuleConfig 两个回调钩子函数。
 baisc-auth 部分核心代码如下：
-```golang
+```go
 func main() {
 	wrapper.SetCtx(
 		"basic-auth",
@@ -309,7 +309,7 @@ func parseOverrideRuleConfig(json gjson.Result, global BasicAuthConfig, config *
 
 CommonPluginCtx 的 NewHttpContext 部分核心代码如下：
 
-```golang
+```go
 func (ctx *CommonPluginCtx[PluginConfig]) NewHttpContext(contextID uint32) types.HttpContext {
 	httpCtx := &CommonHttpCtx[PluginConfig]{
 		plugin:      ctx,
@@ -336,7 +336,7 @@ func (ctx *CommonPluginCtx[PluginConfig]) NewHttpContext(contextID uint32) types
 #### 2.3.2 OnHttpRequestHeaders
 
 OnHttpRequestHeaders 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
 	// 获取当前 HTTP 请求生效插件配置
 	config, err := ctx.plugin.GetMatchConfig()
@@ -365,7 +365,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestHeaders(numHeaders int, end
 #### 2.3.3 OnHttpRequestBody
 
 OnHttpRequestBody 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestBody(bodySize int, endOfStream bool) types.Action {
 	...
 	// 如果不需要处理请求 body，则直接返回，继续后续处理
@@ -404,7 +404,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpRequestBody(bodySize int, endOfStr
 #### 2.3.4 OnHttpResponseHeaders
 
 OnHttpResponseHeaders 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseHeaders(numHeaders int, endOfStream bool) types.Action {
 	...
 	// To avoid unexpected operations, plugins do not read the binary content body
@@ -423,7 +423,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseHeaders(numHeaders int, en
 #### 2.3.5 OnHttpResponseBody
 
 OnHttpResponseBody 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseBody(bodySize int, endOfStream bool) types.Action {
     ...
 	// 如果不需要处理响应 body，则直接返回，继续后续处理
@@ -461,7 +461,7 @@ func (ctx *CommonHttpCtx[PluginConfig]) OnHttpResponseBody(bodySize int, endOfSt
 #### 2.3.6 OnHttpStreamDone
 
 OnHttpStreamDone 核心代码如下：
-```golang
+```go
 func (ctx *CommonHttpCtx[PluginConfig]) OnHttpStreamDone() {
 	...
 	ctx.plugin.vm.onHttpStreamDone(ctx, *ctx.config, ctx.plugin.vm.log)
@@ -473,7 +473,7 @@ OnHttpStreamDone 比较简单，自定义插件有 onHttpStreamDone 回调钩子
 #### 2.3.7 CommonHttpCtx 方法
 
 CommonHttpCtx 提供以下方法，自定义插件可以调用，其代码和注释如下：
-```golang
+```go
 // 设置自定义上下文，这个上下文可以在自定义插件所有回调钩子函数中可以获取
 func (ctx *CommonHttpCtx[PluginConfig]) SetContext(key string, value interface{}) {
 	ctx.userContext[key] = value

--- a/src/content/docs/ebook/zh-cn/wasm17.md
+++ b/src/content/docs/ebook/zh-cn/wasm17.md
@@ -12,7 +12,7 @@ keywords: [Higress]
 Higress 插件的 Go SDK 在进行 HTTP 和 Redis 调用时，是通过指定的集群名称来识别并连接到相应的 Envoy 集群。 此外，Higress 利用 [McpBridge](https://higress.cn/docs/latest/user/mcp-bridge/) 支持多种服务发现机制，包括静态配置（static）、DNS、Kubernetes 服务、Eureka、Consul、Nacos、以及 Zookeeper 等。
 每种服务发现机制对应的集群名称生成规则都有所不同，这些规则在 cluster_wrapper.go 代码文件中有所体现。
 为了包装不同的服务发现机制，Higress 插件 Go SDK 定义了 Cluster 接口，该接口包含两个方法：ClusterName 和 HostName。
-```golang
+```go
 type Cluster interface {
     // 返回 Envoy 集群名称
     ClusterName() string
@@ -23,7 +23,7 @@ type Cluster interface {
 
 ### 1.1 FQDN
 
-```golang
+```go
 
 type FQDNCluster struct {
 	FQDN string
@@ -40,7 +40,7 @@ Host 字段用于发送实际 HTTP 请求时的缺省配置域名，如果在发
 
 ### 1.2 当前路由的服务
 
-```golang
+```go
 type RouteCluster struct {
 	Host string
 }
@@ -48,7 +48,7 @@ type RouteCluster struct {
 集群名称是直接通过 proxywasm.GetProperty([]string{"cluster_name"}) 获取的当前路由的目标集群
 
 ### 1.3 静态配置（static）
-```golang
+```go
 type StaticIpCluster struct {
 	ServiceName string
 	Port        int64
@@ -59,7 +59,7 @@ type StaticIpCluster struct {
 - HostName 规则为：默认为  <service_name>。
 
 ### 1.4 DNS 配置（dns）
-```golang
+```go
 type DnsCluster struct {
 	ServiceName string
 	Domain      string
@@ -71,7 +71,7 @@ type DnsCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回<Domain>。
 
 ### 1.5 Kubernetes 服务（kubernetes）
-```golang
+```go
 
 type K8sCluster struct {
 	ServiceName string
@@ -85,7 +85,7 @@ type K8sCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回 <ServiceName>.<Namespace>.svc.cluster.local。
 
 ### 1.6 Nacos
-```golang
+```go
 
 type NacosCluster struct {
 	ServiceName string
@@ -103,7 +103,7 @@ type NacosCluster struct {
 - HostName 规则为：如果设置 Host，返回 Host，否则返回 <service_name>。
 
 ### 1.7 Consul
-```golang
+```go
 type ConsulCluster struct {
 	ServiceName string
 	Datacenter  string
@@ -117,7 +117,7 @@ type ConsulCluster struct {
 
 ## 2 HTTP 调用
 http_wrapper.go 部分核心代码如下：
-```golang
+```go
 // 回调函数
 type ResponseCallback func(statusCode int, responseHeaders http.Header, responseBody []byte)
 
@@ -142,7 +142,7 @@ type ClusterClient[C Cluster] struct {
 ```
 ClusterClient Get、Head、Options、Post、PUT、Patch、Delete、Connect、Trace、Call 方法最后调用 HttpCall 方法，其核心代码如下：
 
-```golang
+```go
 func HttpCall(cluster Cluster, method, rawURL string, headers [][2]string, body []byte,
 	callback ResponseCallback, timeoutMillisecond ...uint32) error {
 	// 忽略 headers 里设置的保留头
@@ -211,7 +211,7 @@ Token Server 提供 2 个接口：
 
 ### 3.1 插件部分核心代码
 
-```golang
+```go
 package main
 ...
 

--- a/src/content/docs/ebook/zh-cn/wasm18.md
+++ b/src/content/docs/ebook/zh-cn/wasm18.md
@@ -266,7 +266,7 @@ envoy.yaml 配置文件增加了 `outbound|6379||redis.static` 集群，用于�
 ### 3.1 插件配置和配置解析
 
 插件配置和配置解析部分核心代码如下：
-```golang
+```go
 // LimitConfig 定义了限流插件的配置结构。
 type LimitConfig struct {
 	Keys                 []string            `yaml:"keys"`                    // 定义了用于提取限流信息的HTTP请求头字段名称。
@@ -445,7 +445,7 @@ Lua 脚本是在 Redis 中执行的，用于实现令牌桶限流算法。下面
 
 限流主要实现在插件 `onHttpRequestHeaders` 方法中，部分核心代码如下：
 
-```golang
+```go
 // onHttpRequestHeaders 函数在处理 HTTP 请求头时被调用，用于执行限流逻辑。
 func onHttpRequestHeaders(ctx wrapper.HttpContext, config LimitConfig, log wrapper.Log) types.Action {
 	log.Debugf("onHttpRequestHeaders()")

--- a/src/content/docs/ebook/zh-cn/wasm19.md
+++ b/src/content/docs/ebook/zh-cn/wasm19.md
@@ -105,7 +105,7 @@ spec:
 - `_match_service_`：匹配服务生效，填写服务即可，支持通配符。
 
 Higress Controller 控制面转换代码逻辑在 `pkg/ingress/config/ingress_config.go` 文件的 `convertIstioWasmPlugin` func 中实现，其实现代码逻辑比较简单。
-```golang
+```go
 func (m *IngressConfig) convertIstioWasmPlugin(obj *higressext.WasmPlugin) (*extensions.WasmPlugin, error) {
 	...
 }
@@ -113,7 +113,7 @@ func (m *IngressConfig) convertIstioWasmPlugin(obj *higressext.WasmPlugin) (*ext
 
 同时在第`十六章 Higress 插件 Go SDK 与处理流程`中介绍 `CommonPluginCtx` 插件上下文在插件启动时候解析全局/路由/域名/服务级配置，其代码逻辑在 `plugins/wasm-go/pkg/matcher/rule_matcher.go` 文件的 `ParseRuleConfig` func 中实现。
 
-```golang
+```go
 func (m *RuleMatcher[PluginConfig]) ParseRuleConfig(config gjson.Result,
 	parsePluginConfig func(gjson.Result, *PluginConfig) error,
 	parseOverrideConfig func(gjson.Result, PluginConfig, *PluginConfig) error) error {
@@ -121,7 +121,7 @@ func (m *RuleMatcher[PluginConfig]) ParseRuleConfig(config gjson.Result,
 }
 ```
 另外在插件 `OnHttpRequestHeaders` 阶段根据当前请求的 `:authority`、`route_name`、`cluster_name` 获取对应的域名、路由、服务级和全局插件配置。其代码逻辑在 `plugins/wasm-go/pkg/matcher/rule_matcher.go` 文件的 `GetMatchConfig` func 中实现。
-```golang
+```go
 func (m RuleMatcher[PluginConfig]) GetMatchConfig() (*PluginConfig, error) {
 	host, err := proxywasm.GetHttpRequestHeader(":authority")
 	...

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -40,7 +40,7 @@ export default {
 		extend: {
 			fontFamily: {
 				sans: ["Roboto", "SourceHanSans", "sans-serif"],
-				mono: ["Roboto", "SourceHanSans", "sans-serif"],
+				mono: ["SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", "monospace"],
 			},
 			keyframes: {
 				fadeByGroup: {


### PR DESCRIPTION
1. Use monospaced fonts.
2. Fix incorrect code language names.
    ![image](https://github.com/user-attachments/assets/2fbe0594-3c00-4d4f-9c82-2b455b771d63)

### Before

https://higress.cn/blog/skywalking/?spm=36971b57.2ef5001f.0.0.2a932c1fEHuPti&source=blog

![image](https://github.com/user-attachments/assets/3a2f6479-7b45-4d5c-b1dc-a91b599d52c6)

### After

![image](https://github.com/user-attachments/assets/777ad887-1242-42ac-aa7e-7df070135505)