### PR TITLE
docs: escape '|' in markdown table 

### DIFF
--- a/src/content/docs/latest/en/plugins/ai/others/ai-intent.md
+++ b/src/content/docs/latest/en/plugins/ai/others/ai-intent.md
@@ -19,7 +19,7 @@ Plugin execution priority: `700`
 
 | Name           |   Data Type        | Requirement | Default Value | Description                                                      |
 | -------------- | --------------- | ----------- | ------------- | --------------------------------------------------------------- |
-| `scene.category`         | string          | Required     | -             | Preset scene categories, separated by "|", e.g.: "Finance|E-commerce|Law|Higress" |
+| `scene.category`         | string          | Required     | -             | Preset scene categories, separated by "\|", e.g.: "Finance\|E-commerce\|Law\|Higress" |
 | `scene.prompt`         | string          | Optional     | You are a smart category recognition assistant responsible for determining which preset category a user’s question belongs to based on the question posed by the user and the preset categories, and returning the corresponding category. The user's question is: %s, the preset categories are %s, directly return a specific category; if not found, return 'NotFound'.     | llm request prompt template |
 | `llm.proxyServiceName`         | string          | Required     | -             | Newly created Higress service pointing to the large model (use the FQDN value from Higress) |
 | `llm.proxyUrl`         | string          | Required     | -             | The full path to the large model route request address, which can be the gateway’s own address or the address of another large model (OpenAI protocol), for example: http://127.0.0.1:80/intent/compatible-mode/v1/chat/completions |

--- a/src/content/docs/latest/zh-cn/plugins/ai/others/ai-intent.md
+++ b/src/content/docs/latest/zh-cn/plugins/ai/others/ai-intent.md
@@ -24,7 +24,7 @@ LLM 意图识别插件，能够智能判断用户请求与某个领域或agent�
 
 | 名称           |   数据类型        | 填写要求 | 默认值 | 描述                                                         |
 | -------------- | --------------- | -------- | ------ | ------------------------------------------------------------ |
-| `scene.category`         | string          | 必填     | -      | 预设场景类别，以`|`分割，如：`金融|电商|法律|Higress`|
+| `scene.category`         | string          | 必填     | -      | 预设场景类别，以`\|`分割，如：`金融\|电商\|法律\|Higress`|
 | `scene.prompt`         | string          | 非必填     | 你是一个智能类别识别助手，负责根据用户提出的问题和预设的类别，确定问题属于哪个预设的类别，并给出相应的类别。用户提出的问题为:%s,预设的类别为%s，直接返回一种具体类别，如果没有找到就返回'NotFound'。     | llm请求prompt模板 |
 | `llm.proxyServiceName`         | string          | 必填     | -      | 新建的higress服务，指向大模型 (取higress中的 FQDN 值)|
 | `llm.proxyUrl`         | string          | 必填     | -      | 大模型路由请求地址全路径，可以是网关自身的地址，也可以是其他大模型的地址（openai协议），例如：http://127.0.0.1:80/intent/compatible-mode/v1/chat/completions |


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/49c92fa3-678c-4b35-a1a9-173b396c9e6d)
