### PR TITLE
feat(hiclaw): 增加 HiClaw AI 开放平台相关功能与文档

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -21,6 +21,7 @@ import { writeLlmsTxt } from "./src/utils/llmsTxtGenerator.ts";
 const zhDocsSidebar = loadSidebarConfig("root", "docs");
 const zhAiSidebar = loadSidebarConfig("root", "ai");
 const zhHimarketSidebar = loadSidebarConfig("root", "himarket");
+const zhHiclawSidebar = loadSidebarConfig("root", "hiclaw");
 const zhDeveloperSidebar = loadSidebarConfig("root", "developer");
 
 // Custom integration to copy markdown files
@@ -132,6 +133,10 @@ export default defineConfig({
         {
           label: sidebarCategory.himarket,
           items: zhHimarketSidebar,
+        },
+        {
+          label: sidebarCategory.hiclaw,
+          items: zhHiclawSidebar,
         },
         {
           label: sidebarCategory.developer,

--- a/src/components/starlight/PageFrame.astro
+++ b/src/components/starlight/PageFrame.astro
@@ -12,7 +12,8 @@ const t = useTranslations(locale);
 const options = [
   { label: t('page.header.gateway'), value: 'gateway' },
   { label: t('page.header.ai.gateway'), value: 'ai' },
-  { label: t('page.header.himarket'), value: 'himarket' }
+  { label: t('page.header.himarket'), value: 'himarket' },
+  { label: t('page.header.hiclaw'), value: 'hiclaw' }
 ];
 
 // Determine current value based on URL
@@ -22,6 +23,8 @@ if (pathname.includes('/ai/')) {
   currentValue = 'ai';
 } else if (pathname.includes('/himarket')) {
   currentValue = 'himarket';
+} else if (pathname.includes('/hiclaw')) {
+  currentValue = 'hiclaw';
 }
 
 const isDevelopers = pathname.includes(sidebarCategory.developer)
@@ -151,7 +154,9 @@ const isDevelopers = pathname.includes(sidebarCategory.developer)
     if (value === 'ai') {
       url = sidebarCategoryDefaultLink.ai;
     } else if (value === 'himarket') {
-      url = sidebarCategoryDefaultLink.himarket; // Placeholder for HiMarket
+      url = sidebarCategoryDefaultLink.himarket;
+    } else if (value === 'hiclaw') {
+      url = sidebarCategoryDefaultLink.hiclaw;
     }
 
     // Handle Locale

--- a/src/components/starlight/Sidebar.astro
+++ b/src/components/starlight/Sidebar.astro
@@ -11,6 +11,7 @@ const pathname = Astro.url.pathname;
 const isLatestDocs = pathname.includes(sidebarCategory.latest);
 const isAi = pathname.includes(sidebarCategory.ai);
 const isHimarket = pathname.includes(sidebarCategory.himarket)
+const isHiclaw = pathname.includes(sidebarCategory.hiclaw)
 const isDevelopers = pathname.includes(sidebarCategory.developer)
 
 // Filter sidebar groups based on context
@@ -21,6 +22,8 @@ const filteredSidebar = sidebar.filter((entry) => {
     return entry.label.includes(sidebarCategory.ai);
   } else if (isHimarket) {
     return entry.label.includes(sidebarCategory.himarket);
+  } else if (isHiclaw) {
+    return entry.label.includes(sidebarCategory.hiclaw);
   } else if (isDevelopers) {
     return entry.label.includes(sidebarCategory.developer);
   } else {

--- a/src/container/Navbar.astro
+++ b/src/container/Navbar.astro
@@ -29,6 +29,7 @@ const navItems = [
       { label: t('page.header.gateway'), href: localizeUrl('/api-gateway', locale) },
       { label: t('page.header.ai.gateway'), href: localizeUrl('/ai-gateway', locale) },
       { label: 'HiMarket', href: localizeUrl('/himarket', locale) },
+      { label: 'HiClaw', href: localizeUrl('/hiclaw', locale) },
     ]
   },
   {

--- a/src/container/products/HiClaw.astro
+++ b/src/container/products/HiClaw.astro
@@ -1,0 +1,143 @@
+---
+import ProductHeader from "./Header.astro";
+import Button from "../../components/button/Button.astro";
+import Section from "../common/section.astro";
+import Layout from "./Layout.astro";
+import { LINKS } from "@/constant";
+
+import { useTranslations } from "@/i18n/utils";
+
+const locale = Astro.currentLocale || 'root';
+const t = useTranslations(locale);
+const isEn = locale === "en";
+
+const products = [
+  {
+    label: t('hiclaw.product.ai_market'),
+    desc: t('hiclaw.product.ai_market.desc'),
+    link: LINKS.himarketConsole,
+    img: "https://img.alicdn.com/imgextra/i2/O1CN01H62z3z1oVOXevp4zZ_!!6000000005230-55-tps-312-204.svg",
+  },
+  {
+    label: t('hiclaw.product.hichat'),
+    desc: t('hiclaw.product.hichat.desc'),
+    link: LINKS.himarketConsole,
+    img: "https://img.alicdn.com/imgextra/i4/O1CN01VixIjB1VJ3AKQVKA4_!!6000000002631-55-tps-312-204.svg",
+  },
+  {
+    label: t('hiclaw.product.enterprise_capability'),
+    desc: t('hiclaw.product.enterprise_capability.desc'),
+    link: LINKS.himarketConsole,
+    img: "https://img.alicdn.com/imgextra/i3/O1CN01pVExX328Xx4Iup8cj_!!6000000007943-55-tps-312-204.svg",
+  },
+  {
+    label: t('hiclaw.product.extension_capability'),
+    desc: t('hiclaw.product.extension_capability.desc'),
+    link: LINKS.himarketConsole,
+    img: isEn ? "https://img.alicdn.com/imgextra/i1/O1CN01risH211CGmVOSmSLM_!!6000000000054-55-tps-268-214.svg" : "https://img.alicdn.com/imgextra/i2/O1CN018wcXBp27hjuucntK8_!!6000000007829-55-tps-268-214.svg",
+  },
+];
+
+const imgSrc = isEn ? "https://img.alicdn.com/imgextra/i4/O1CN01k1kgpT1N8V7PEGqZG_!!6000000001525-55-tps-1360-744.svg" : "https://img.alicdn.com/imgextra/i4/O1CN01HpkiiO1spmdXNna5f_!!6000000005816-55-tps-1360-744.svg";
+
+---
+
+<ProductHeader title={t('page.header.hiclaw')} />
+<Layout>
+  <Section
+    title={t('api.product.intro.title')}
+    desc={t('hiclaw.product.intro.desc')}
+  >
+    <div class="flex flex-col md:flex-row gap-3 w-full md:w-auto" slot="buttonGroup">
+      <Button href={LINKS.himarketConsole} target="_blank" class="w-full md:w-59.5">
+        {t('api.product.button.experience')}
+      </Button>
+      <Button href={LINKS.himarketGithub} target="_blank" class="w-full md:w-59.5" mode="normal">
+        <span class="mr-3">GitHub</span>
+        <svg class="fill-black" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="none" version="1.1" width="8" height="8" viewBox="0 0 12 12">
+          <g transform="matrix(-1,0,0,1,24,0)">
+            <path d="M13.9085488,3.2445331L13.9085488,10.49702Q13.9085488,10.902587,13.633718,11.177418Q13.358887,11.177418,12.954274,11.151293Q12.54870754,11.451293,12.27483088,11.176462Q12.00095420511,10.90163,12,10.49702L12,0.95427454Q12,0.54870796,12.27483088,0.27483124Q12.54966176,0.0009545465,12.954274,0L22.497017,0Q22.902583999999997,0,23.177414,0.27483088Q23.452244,0.54966176,23.451292000000002,0.95427454Q23.451292000000002,1.3598411,23.17646,1.6346719Q22.901628000000002,1.909503,22.497017,1.9085487L15.2445326,1.9085487L23.737576,10.401592Q24,10.664019,24,11.069584Q24,11.475149,23.737576,11.737576Q23.475149000000002,12,23.069584,12Q22.664019,12,22.401592,11.737576L13.9085488,3.2445331Z" fill-opacity="1"/>
+          </g>
+        </svg>
+      </Button>
+    </div>
+    <img slot="content" class="max-w-full" src={imgSrc} alt="HiClaw Feature" />
+  </Section>
+  <Section
+    title={t('hiclaw.product.core_features.title')}
+    desc={t('hiclaw.product.core_features.desc')}
+  >
+    <div slot="content" class="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mt-10">
+      {
+        products.map(s => {
+          return (
+          <div class="card flex flex-col gap-3">
+            <div class="card-header rounded-lg">
+              <div class="flex justify-center items-center w-full h-full">
+                <img class="max-w-full max-h-full" src={s.img} alt="Feature Icon">
+              </div>
+            </div>
+            <div class="flex flex-col gap-3">
+              <div class="text-center md:text-left text-black text-lg font-normal">{s.label}</div>
+              <div class="text-black text-sm leading-9">
+                {s.desc}
+              </div>
+              <a href={s.link} target="_blank" class="detail-link text-primary text-xs inline-flex items-center gap-1">
+                <span>{t('home.sense.detail.link')}</span>
+                <svg class="detail-arrow fill-primary" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" fill="none" version="1.1" width="8" height="8" viewBox="0 0 12 12">
+                  <g transform="matrix(-1,0,0,1,24,0)">
+                    <path d="M13.9085488,3.2445331L13.9085488,10.49702Q13.9085488,10.902587,13.633718,11.177418Q13.358887,11.177418,12.954274,11.151293Q12.54870754,11.451293,12.27483088,11.176462Q12.00095420511,10.90163,12,10.49702L12,0.95427454Q12,0.54870796,12.27483088,0.27483124Q12.54966176,0.0009545465,12.954274,0L22.497017,0Q22.902583999999997,0,23.177414,0.27483088Q23.452244,0.54966176,23.451292000000002,0.95427454Q23.451292000000002,1.3598411,23.17646,1.6346719Q22.901628000000002,1.909503,22.497017,1.9085487L15.2445326,1.9085487L23.737576,10.401592Q24,10.664019,24,11.069584Q24,11.475149,23.737576,11.737576Q23.475149000000002,12,23.069584,12Q22.664019,12,22.401592,11.737576L13.9085488,3.2445331Z" fill-opacity="1"/>
+                  </g>
+                </svg>
+              </a>
+            </div>
+          </div>
+          )
+        })
+      }
+    </div>
+  </Section>
+</Layout>
+<style>
+.card {
+  .card-header {
+    background-image: url("https://img.alicdn.com/imgextra/i1/O1CN01L0NG3P1VgrlKrpDqR_!!6000000002683-2-tps-312-197.png");
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 200px;
+  }
+}
+
+.detail-link {
+  position: relative;
+  transition: all 0.3s ease;
+  width: fit-content;
+}
+
+.detail-link::after {
+  content: '';
+  position: absolute;
+  bottom: -2px;
+  left: 0;
+  width: 0;
+  height: 1px;
+  background-color: currentColor;
+  transition: width 0.3s ease;
+}
+
+.detail-link:hover::after {
+  width: 100%;
+}
+
+.detail-link:hover {
+  opacity: 0.8;
+}
+
+.detail-arrow {
+  transition: transform 0.3s ease;
+}
+
+.detail-link:hover .detail-arrow {
+  transform: translateX(4px);
+}
+</style>

--- a/src/content/docs/docs/hiclaw/_sidebar.json
+++ b/src/content/docs/docs/hiclaw/_sidebar.json
@@ -1,0 +1,25 @@
+[
+  {
+    "label": "HiClaw",
+    "translations": {
+      "en": "HiClaw"
+    },
+    "collapsed": false,
+    "items": [
+      {
+        "label": "HiClaw 介绍",
+        "translations": {
+          "en": "HiClaw Introduction"
+        },
+        "link": "docs/hiclaw-introduction"
+      },
+      {
+        "label": "HiClaw 部署",
+        "translations": {
+          "en": "HiClaw Deployment"
+        },
+        "link": "docs/hiclaw-deployment"
+      }
+    ]
+  }
+]

--- a/src/content/docs/docs/hiclaw/hiclaw-deployment.md
+++ b/src/content/docs/docs/hiclaw/hiclaw-deployment.md
@@ -1,0 +1,264 @@
+---
+title: "HiClaw 部署指南"
+description: "HiClaw 快速部署与安装配置指南"
+date: "2025-12-12"
+category: "article"
+keywords: ["HiClaw", "部署", "安装"]
+authors: "Higress Team"
+---
+
+# HiClaw 部署指南
+
+## 一、本地搭建
+
+**环境依赖：** JDK 17、Node.js 18+、Maven 3.6+、MySQL 8.0+
+
+**启动后端：**
+
+```bash
+# 构建项目
+mvn clean package -DskipTests
+
+# 启动后端服务
+java --add-opens java.base/java.util=ALL-UNNAMED \
+     --add-opens java.base/java.lang=ALL-UNNAMED \
+     --add-opens java.base/java.lang.reflect=ALL-UNNAMED \
+     -Ddb.host=${DB_HOST} \
+     -Ddb.port=${DB_PORT} \
+     -Ddb.name=${DB_NAME} \
+     -Ddb.username=${DB_USERNAME} \
+     -Ddb.password=${DB_PASSWORD} \
+     -jar hiclaw-bootstrap/target/hiclaw-bootstrap-1.0-SNAPSHOT.jar
+
+# 后端 API 地址：http://localhost:8080
+```
+
+**启动前端：**
+
+```bash
+# 启动管理后台
+cd hiclaw-web/hiclaw-admin
+npm install
+npm run dev
+# 管理后台地址：http://localhost:5174
+
+# 启动开发者门户
+cd hiclaw-web/hiclaw-frontend
+npm install
+npm run dev
+# 开发者门户地址：http://localhost:5173
+```
+
+## 二、基于 Docker Compose 部署
+
+包含七个服务组件：
+
++ **mysql：** 数据库服务，为后端服务提供数据存储；
++ **hiclaw-server：** 后端服务，运行在 8081 端口；
++ **hiclaw-admin：** 管理后台界面，运行在 5174 端口，供管理员配置 Portal；
++ **hiclaw-frontend：** 前台用户界面，运行在 5173 端口，供用户浏览和使用 API Product；
++ **Higress：** Higress all-in-one 网关服务，运行在 8443、8082、8001 端口，其中控制台运行在 8001 端口，供用户浏览和使用；
++ **Redis：** Higress 缓存服务；
++ **Nacos：** Nacos 服务，运行在 8080、8848、9848 端口，其中控制台运行在 8080 端口，供用户浏览和使用。
+
+### 安装命令
+
+**环境依赖：** docker、docker compose、curl、jq
+
+**一键拉起：** 使用 `deploy.sh` 脚本完成 HiClaw、Higress、Nacos 全栈部署和数据初始化。
+
+```bash
+# 克隆项目
+git clone https://github.com/higress-group/hiclaw.git
+cd hiclaw/deploy/docker/scripts
+
+# 部署全栈服务并初始化
+./deploy.sh install
+
+# 或仅部署 HiClaw 服务（不含 Nacos/Higress）
+./deploy.sh hiclaw-only
+
+# 卸载所有服务
+./deploy.sh uninstall
+
+# 服务地址
+# 管理后台地址：http://localhost:5174
+# 开发者门户地址：http://localhost:5173
+# 后端 API 地址：http://localhost:8081
+```
+
+该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+
+```bash
+cd docker/scripts/hooks/post_ready.d
+
+# 重试失败脚本
+./10-init-nacos-admin.sh
+```
+
+### 安装配置
+
+所有配置集中在 `scripts/data/.env` 文件中：
+
+```bash
+cd docker/scripts/data
+vi .env
+```
+
+| 配置名 | 配置说明 | **默认值** |
+| --- | --- | --- |
+| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 123456 |
+| MYSQL_DATABASE | MySQL 数据库名 | portal_db |
+| MYSQL_USER | MySQL 用户名 | portal_user |
+| MYSQL_PASSWORD | MySQL 密码 | portal_pass |
+| USE_BUILTIN_MYSQL | 是否使用内置 MySQL（true/false） | true |
+| DB_HOST | 数据库地址（使用外置数据库时必填） | mysql |
+| DB_PORT | 数据库端口（使用外置数据库时必填） | 3306 |
+| DB_NAME | 数据库名称（使用外置数据库时必填） | portal_db |
+| DB_USERNAME | 数据库用户名（使用外置数据库时必填） | portal_user |
+| DB_PASSWORD | 数据库密码（使用外置数据库时必填） | portal_pass |
+| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
+| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
+| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
+| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
+| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
+| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
+| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
+| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
+| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
+| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
+| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
+| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
+| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| HIGRESS_USERNAME | Higress 登录用户名 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| ADMIN_USERNAME | 后台管理员用户名 | admin |
+| ADMIN_PASSWORD | 后台管理员密码 | admin |
+| FRONT_USERNAME | 前台默认用户名 | demo |
+| FRONT_PASSWORD | 前台默认密码 | demo123 |
+| NACOS_IMAGE | Nacos 镜像地址 | nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.1.1 |
+| NACOS_AUTH_IDENTITY_KEY | Nacos 认证身份标识 Key | serverIdentity |
+| NACOS_AUTH_IDENTITY_VALUE | Nacos 认证身份标识 Value | security |
+| NACOS_AUTH_TOKEN | Nacos 认证 Token | VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg= |
+| HIGRESS_IMAGE | Higress 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest |
+| HICLAW_SERVER_IMAGE | HiClaw 后端服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/hiclaw-server:latest |
+| HICLAW_ADMIN_IMAGE | HiClaw 管理后台镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/hiclaw-admin:latest |
+| HICLAW_FRONTEND_IMAGE | HiClaw 前台服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/hiclaw-frontend:latest |
+| REDIS_IMAGE | Redis 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3 |
+| MYSQL_IMAGE | MySQL 镜像地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest |
+
+
+## 三、使用 Helm 进行云原生部署
+
+Helm 是一个用于自动化管理和发布 Kubernetes 软件的包管理系统。通过 Helm 一键部署脚本您可以在 Kubernetes 集群上快速部署安装 HiClaw+Higress+Nacos，包含十个服务组件：
+
++ **HiClaw：**
+    - hiclaw-server：HiClaw AI 开放平台的后端服务；
+    - hiclaw-admin：HiClaw AI 开放平台管理后台，管理员通过此界面配置 Portal；
+    - hiclaw-frontend：HiClaw AI 开放平台的前台服务，用户通过此界面浏览和使用 API；
+    - mysql：可选内置数据库。
++ **Higress：**
+    - higress-console：控制台，用户通过此界面浏览和使用 Higress 服务；
+    - higress-controller：控制面组件，负责管理配置下发；
+    - higress-gateway：数据面组件，负责承载数据流量；
+    - redis-stack-server：缓存组件。
++ **Nacos：**
+    - nacos：Nacos 应用；
+    - nacos-mysql：Nacos 数据库。
+
+**服务类型说明：**
+
+默认为 LoadBalancer 类型服务，适用于云环境（阿里云 ACK、AWS EKS 等）。如果您的环境不支持 LoadBalancer（如本地 minikube、自建集群），可以使用 NodePort 或端口转发方式访问。后台配置好 HiClaw 后，将域名解析到 hiclaw-frontend 服务的访问地址，用户就可以通过域名访问前台站点。
+
+### 安装命令
+
+**环境依赖：** kubectl、python3/python、curl、jq
+
+**一键拉起：** 使用 `deploy.sh` 脚本将 HiClaw 部署到 Kubernetes 集群。
+
+```bash
+# 克隆项目
+git clone https://github.com/higress-group/hiclaw.git
+cd hiclaw/deploy/helm/scripts
+
+# 部署全栈服务并初始化
+./deploy.sh install
+
+# 或仅部署 HiClaw 服务（不含 Nacos/Higress）
+./deploy.sh hiclaw-only
+
+# 卸载
+./deploy.sh uninstall
+```
+
+该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+
+```bash
+cd helm/scripts/hooks/post_ready.d
+
+# 重试失败脚本
+./10-init-nacos-admin.sh
+```
+
+### 安装配置
+
+相关配置集中在 `scripts/data/.env` 文件中：
+
+```bash
+cd helm/scripts/data
+vi .env
+```
+
+| 配置名 | 配置说明 | **默认值** |
+| --- | --- | --- |
+| NAMESPACE | Kubernetes 命名空间 | hiclaw-system |
+| HICLAW_ONLY | 仅部署 HiClaw（跳过 Nacos/Higress） | false |
+| HICLAW_IMAGE_TAG | HiClaw 镜像标签 | latest |
+| HICLAW_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
+| HICLAW_MYSQL_ENABLED | 是否使用内置 MySQL（true/false） | true |
+| EXTERNAL_DB_HOST | 外部数据库地址（HICLAW_MYSQL_ENABLED=false 时使用） | Your_External_DB_Host |
+| EXTERNAL_DB_PORT | 外部数据库端口 | 3306 |
+| EXTERNAL_DB_NAME | 外部数据库名称 | Your_DB_Name |
+| EXTERNAL_DB_USERNAME | 外部数据库用户名 | Your_DB_Username |
+| EXTERNAL_DB_PASSWORD | 外部数据库密码 | Your_DB_Password |
+| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
+| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
+| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
+| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
+| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
+| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
+| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
+| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
+| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
+| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
+| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
+| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
+| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| HIGRESS_USERNAME | Higress 登录用户名 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| ADMIN_USERNAME | 后台管理员用户名 | admin |
+| ADMIN_PASSWORD | 后台管理员密码 | admin |
+| FRONT_USERNAME | 前台默认用户名 | demo |
+| FRONT_PASSWORD | 前台默认密码 | demo123 |
+| NACOS_VERSION | Nacos 镜像版本 | v3.1.1 |
+| NACOS_IMAGE_REGISTRY | Nacos 镜像仓库 | nacos-registry.cn-hangzhou.cr.aliyuncs.com |
+| NACOS_IMAGE_REPOSITORY | Nacos 镜像地址 | nacos/nacos-server |
+| HIGRESS_REPO_NAME | Higress Helm 仓库名称 | higress.io |
+| HIGRESS_REPO_URL | Higress Helm 仓库地址 | https://higress.cn/helm-charts |
+| HIGRESS_CHART_REF | Higress Chart 引用 | higress.io/higress |
+| NACOS_REPO_NAME | Nacos Helm 仓库名称 | ygqygq2 |
+| NACOS_REPO_URL | Nacos Helm 仓库地址 | https://ygqygq2.github.io/charts/ |
+| NACOS_CHART_REF | Nacos Chart 引用 | ygqygq2/nacos |
+| HICLAW_HUB | HiClaw 镜像仓库地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group |
+| HICLAW_IMAGE_TAG | HiClaw 镜像标签 | latest |
+| HICLAW_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
+
+
+注：HiClaw 的 Helm 包适配阿里云 ACK 集群使用，/helm/values.yaml 文件下存储类 persistence.storageClass: "alicloud-disk-essd"  值需根据实际环境调整。
+
+## 四、云平台部署（阿里云）
+
+阿里云计算巢支持该项目的开箱即用版本，可一键部署社区版：[![Deploy on AlibabaCloud ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest.svg)](https://computenest.console.aliyun.com/service/instance/create/cn-hangzhou?type=user&ServiceId=service-b96fefcb748f47b7b958)
+

--- a/src/content/docs/docs/hiclaw/hiclaw-introduction.md
+++ b/src/content/docs/docs/hiclaw/hiclaw-introduction.md
@@ -1,0 +1,196 @@
+---
+title: "HiClaw 介绍"
+description: "HiClaw 产品介绍与核心功能概览"
+date: "2025-12-11"
+category: "article"
+keywords: ["HiClaw", "介绍", "产品"]
+authors: "Higress Team"
+---
+
+# HiClaw 介绍
+
+随着AI浪潮面向全行业进行重塑，大量的企业需要进行 AI 场景在内部落地，企业架构逐步升级成 AI 原生架构，实际落地当中有很多问题：
+
++ 企业内各个团队分散使用各种模型，内部重复造轮子，规模增大，如何统一管理？
++ 企业内个人使用公网模型、公网获取回来的 MCP ，是否安全，会不会泄露公司数据？
++ 企业使用 AI 成本和效果怎么测算，SLA 如何量化，Token 用量如何量化，是否统一可量化可观测？
++ 企业内部面向 AI 全员提升效率，面向私有模型、公网模型，如何分配账号和权限进行管理？
+
+当企业开始大规模部署 AI 应用时，往往会遇到这样的难题，当这些资源超过一定规模后，问题会变得越来越复杂，最终制约 AI 应用的进一步发展。
+
+## 一、HiClaw 是什么
+HiClaw 正是为解决这些问题而生，它是一个基于 Higress AI 网关构建的 AI 开放平台，旨在帮助企业快速构建私有的 AI 能力市场，统一管理 Model、MCP Server、Agent 等 AI 资源，HiClaw 提供从资源管理到开发者生态构建的完整解决方案，可作为企业内部链接 AI 的最短路径，让企业内部 AI 入口统一。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/f410002b-4932-4dc8-baf9-226709be7246)
+
+</div>
+
+## 二、使用场景
+
+## AI 场景（面对企业员工）
+HiClaw 提供了 HiChat 能力，通过 Chat 模式替代搜索，做市场调研和产品调研，生成运营图片等工作。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/1d17f995-cf79-4ab9-bc36-8ccde5afcd47)
+
+</div>
+
++ **企业全员 AI 使用入口**：通过 HiClaw AI 开放平台，同时解决了员工不知道用哪些模型，企业如何管控员工用模型的两个问题；全员可以通过这个入口进行使用 AI 模型能力，企业可以进行整体安全合规审核，保证企业和员工使用 AI 范围安全可控。
++ **多模型对比**：可以选择多个模型市场的模型，输入一次对比多个模型，快速直接对比模型返回内容差异，选取最优内容。
++ **会话历史记录**：方便员工管理历史会话记录，可以快速基于历史信息进行对话回溯，并且计划后续基于对话可以形成知识点，知识点可以进行横向传递，提升数据共享效率。
++ **联网搜索**：通过体验中心可以支持配置联网搜索能力，配置 Higress AI 网关联网搜索能力之后，所有模型都可以支持联网搜索，AI 网关会把对应搜索内容传递给模型使用摘取，扩大实时数据能力。
++ **支持关联 MCP 工具**：体验中心聊天框支持关联 MCP 市场，可以实时快速的使用 MCP 能力，可以快速体验验证 MCP 本身能力情况，并且支持企业原本 API 快速配置化转换成 MCP 协议，结合模型做快速验证。
+
+## AI 市场（面对开发者）
+HiClaw 支持构建涵盖 Agent、MCP Server、Model 的完整 AI 市场，让企业的各类 AI 资源不再分散，而是以标准化方式汇聚在一个平台上。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/9caefd86-7bbe-44c9-8c77-b53b74ff05fb)
+
+</div>
+
++ **Agent 市场**：支持将复杂的 AI Agent 应用打包上架，可对接 AgentScope 等 Agent 开发平台，例如通过 AgentScope 构建的 Agent 可一键注册到 HiClaw，其他开发者订阅后即可直接使用，无需从零搭建；支持跨框架、跨语言的 agent 一键发布到 Agent 市场。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/4c0da704-47da-484c-9d18-1711084d72a5)
+
+</div>
+
++ **MCP 市场**：支持接入不同平台的 MCP Server，并支持将外部 API 转换为标准化的 MCP Server，开发者订阅后，即可让 AI 应用轻松调用外部能力。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/69184181-8cfe-498c-a0c5-494efa55d72e)
+
+</div>
+
++ **模型市场**：支持公有云模型及企业自研私有模型的快速接入，平台以 Higress 作为模型服务的网关代理，提供内容安全、Token 限流等防护能力，保障模型服务对外开放的安全合规。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/2ed00358-1031-4146-8eb0-2e372b89d82e)
+
+</div>
+
++ **AI 资产生命周期管理**：管理员将资源接入平台，配置访问策略和使用文档，发布上架；开发者在门户浏览、订阅、获取调用凭证即可订阅使用。
+
+## AI 治理（面对AI维护者）
+HiClaw 实现了对 AI 资源的集中式治理，提供全方位的安全管控和协作能力：
+
++ **安全合规保障**：通过 Higress 网关统一管控所有 AI 资源的访问，支持内容安全检测、敏感信息过滤、访问权限控制，确保企业 AI 能力对外开放时符合安全合规要求。
++ **高效协作共享**：打破团队间的"能力孤岛"，一个模型或工具接入后，可被多个部门订阅复用，避免重复采购和重复开发。
++ **降低使用门槛**：开发者无需逐一对接不同厂商的 API，HiClaw 提供统一的协议标准和开箱即用的调用凭证，大幅降低接入成本，让团队更专注于业务创新而非基础设施搭建。
+
+
+
+## 三、产品优势
+### 企业级能力
+HiClaw 内置完善的企业级管理能力，确保 AI 资源的安全开放与高效运营。
+
++ **产品管理：** 管理员可为不同 API 产品配置独立的认证鉴权和可见性策略，同时提供流量控制、IP 白名单等防护能力，保障服务安全稳定。
++ **观测分析：** 提供管理员视角的全局观测大盘，展示 AI API 的调用趋势、热门产品排行、异常流量预警等，支持按时间、产品类型、开发者等维度进行多维分析，为企业运营优化提供数据依据。
++ **计量计费：** 支持基于 Token、调用次数等多种计量模式，自动统计资源消耗并生成账单明细，既能服务企业内部的成本核算，也能支撑对外商业化运营。
++ **版本管理：** 支持 API 产品的多版本并行，管理员可以发布新版本、维护旧版本并平滑迁移用户，通过版本对比、灰度发布、快速回滚等功能，确保产品迭代的安全稳定。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/07e120fa-20e9-4eff-a30d-6c8b2651b578)
+
+</div>
+
+### 丰富观测能力
+观测分析（目前 v0.5.0 版本依赖阿里云商业化 SLS，开源版本的观测分析实现计划在后续版本中提供）：
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/d5e7b54e-008a-439e-8753-6cd7d4f304fe)
+
+</div>
+
+### 灵活扩展能力
+
+
+为了能够快速对接企业现有的系统，HiClaw 提供了灵活的定制能力，包括：
+
++ **门户品牌：** 管理员可为门户配置自定义域名、Logo、主题色、布局样式等元素，并灵活配置首页模块、产品分类、推荐栏等功能区域。
++ **身份认证：** 支持内置账号密码和企业 OIDC 认证方式，可与企业 SSO、IDaaS 等身份系统无缝集成，实现统一的用户管理和身份认证。
++ **审批流程：** 开发者注册、凭证申请、API 订阅等关键流程可灵活配置自动或人工审批。
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/06112d40-0883-4d32-8689-c0ed4c45b459)
+
+</div>
+
+## 四、快速体验
+HiClaw 提供多种部署方式，满足不同场景需求：
+
++ 本地快速体验： [HiClaw 本地部署指南](https://github.com/higress-group/hiclaw/blob/main/README.md)。
++ Docker Compose 部署： [HiClaw Docker 部署指南](https://github.com/higress-group/hiclaw/blob/main/deploy/docker/Docker%E9%83%A8%E7%BD%B2%E8%AF%B4%E6%98%8E.md)。
++ Kubernetes 部署：[HiClaw Helm 部署指南](https://github.com/higress-group/hiclaw/blob/main/deploy/helm/Helm%E9%83%A8%E7%BD%B2%E8%AF%B4%E6%98%8E.md)。
+
+### 一键部署，开箱即用的完整方案
+HiClaw、Higress、Nacos 三大组件自动编排部署，无需人工干预。部署过程自动完成示例 MCP Server 的注册、配置和发布，让你在部署完成后即可体验 HiClaw 能力市场。无论是 Docker Compose 还是 Kubernetes 部署，均只需一条命令:
+
+```bash
+./deploy.sh install
+```
+
+部署脚本会自动完成以下所有工作:
+
++ **核心组件部署**：自动拉起 MySQL、Nacos 配置中心、Higress 网关服务
++ **应用本体部署**：部署 HiClaw 全套服务(管理后台、开发者门户、后端服务)
++ **智能初始化**：自动创建管理员账号、配置示例 MCP Server、发布演示 API 产品
++ **即开即用**：部署完成后即可访问管理后台和开发者门户，无需任何手动配置
+
+方案支持灵活的场景适配：
+
++ 支持使用内置 MySQL 或对接已有数据库
++ 支持使用阿里云商业化 MSE 服务和 AI 网关服务
++ 支持`./deploy.sh hiclaw-only`仅部署 HiClaw 本体
+
+详细步骤请参考：[HiClaw Docker 一键部署指南](https://github.com/higress-group/hiclaw/blob/main/deploy/docker/Docker%E9%83%A8%E7%BD%B2%E8%84%9A%E6%9C%AC%E8%AF%B4%E6%98%8E.md)，[HiClaw Helm 一键部署指南](https://github.com/higress-group/hiclaw/blob/main/deploy/helm/Helm%E9%83%A8%E7%BD%B2%E8%84%9A%E6%9C%AC%E8%AF%B4%E6%98%8E.md)
+
+
+
+## 五、HiClaw Roadmap 规划
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/ebc9697c-c52c-4bd0-b71a-36bd3b9934f1)
+
+</div>
+
+## 六、欢迎共建
+HiClaw 是多个开源社区共同发起的开源项目，核心参与者包括阿里云、蚂蚁数科、高德、淘天等团队，面向开源可以助力企业快速构建 AI 开放平台，提供开箱即用的能力。
+
+HiClaw 仓库：
+
+[https://github.com/higress-group/HiClaw](https://github.com/higress-group/hiclaw)  
+基于 HiClaw 实现的 MCP 金融级市场
+
+[https://antdigital.com/products/MCP](https://antdigital.com/products/MCP)
+
+
+
+HiClaw 钉钉社区群（2群）：163370001036
+
+<div align="center">
+
+![](https://github.com/user-attachments/assets/b0705600-df08-42ef-9e1b-d28c77896415)
+
+</div>
+
+[https://qr.dingtalk.com/action/joingroup?code=v1,k1,d+MJWsDVtfHq6XanvQEUxsVX3vVL1m+7DWfkoUkYxVM=&_dt_no_comment=1&origin=11](https://qr.dingtalk.com/action/joingroup?code=v1,k1,d+MJWsDVtfHq6XanvQEUxsVX3vVL1m+7DWfkoUkYxVM=&_dt_no_comment=1&origin=11)
+
+
+
+推荐文章：
+
+《AgentScope Java v1.0 发布，让 Java 开发者轻松构建企业级 Agentic 应用》[https://mp.weixin.qq.com/s/vtb3t0JnSTau3XM6wJMEkw](https://mp.weixin.qq.com/s/vtb3t0JnSTau3XM6wJMEkw)
+

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,6 +4,7 @@ export default {
   "page.header.gateway": "API Gateway",
   "page.header.ai.gateway": "AI Gateway",
   "page.header.himarket": "HiMarket",
+  "page.header.hiclaw": "HiClaw",
   "navbar.product": "Product",
   "navbar.product.features": "Features",
   "navbar.product.benefits": "Benefits",
@@ -741,6 +742,23 @@ export default {
 
     'himarket.product.extension_capability': 'Extensibility',
     'himarket.product.extension_capability.desc': 'HiMarket offers flexible customization to quickly integrate with existing enterprise systems. The portal supports custom domains and branding styles, and homepage modules and product categories can be configured on demand. Identity authentication is compatible with username/password and enterprise OIDC/SSO/IDaaS integration, while key processes (registration, credential application, subscription) support automatic or manual approval configurations.',
+
+    // HiClaw Product Page
+    'hiclaw.product.intro.desc': 'Empower enterprises to build Agent, Model, and MCP markets. Through a unified AI capability management platform, it solves challenges such as dispersed AI resources, complex permission control, and difficult cost allocation. The platform provides HiChat AI Innovation Center as a unified AI entry for all staff, breaking down capability silos between teams, reducing access costs, and unleashing AI innovation potential.',
+    'hiclaw.product.core_features.title': 'Core Features',
+    'hiclaw.product.core_features.desc': 'HiClaw brings out-of-the-box, rapidly integrated AI capabilities to enterprises.',
+
+    'hiclaw.product.ai_market': 'AI Marketplace',
+    'hiclaw.product.ai_market.desc': 'Supports building a complete AI marketplace covering Agents, MCP Servers, and Models. It gathers various AI resources of the enterprise in a standardized way on a single platform, forming a unified supply and management of AI capabilities, rather than being scattered.',
+
+    'hiclaw.product.hichat': 'HiChat',
+    'hiclaw.product.hichat.desc': 'HiChat replaces search with conversation, covering market/product research and operational content generation. It serves as a unified AI entry point for all enterprise staff, centralizing multi-model selection and usage with security compliance control. The platform supports single-input multi-model comparison, session history retention and reuse, and enables unified web search and MCP tool association/conversion through Higress AI Gateway for rapid validation and capability extension.',
+
+    'hiclaw.product.enterprise_capability': 'Enterprise Capabilities',
+    'hiclaw.product.enterprise_capability.desc': 'Provides a closed-loop enterprise management system. Administrators can configure authentication and visibility for each API product, ensuring security and stability with capabilities like traffic control and IP allowlists. The platform also supports global observability analysis, metering and billing by Token/call count, as well as multi-version parallel canary releases and rapid rollbacks to support efficient operations and stable iteration.',
+
+    'hiclaw.product.extension_capability': 'Extensibility',
+    'hiclaw.product.extension_capability.desc': 'HiClaw offers flexible customization to quickly integrate with existing enterprise systems. The portal supports custom domains and branding styles, and homepage modules and product categories can be configured on demand. Identity authentication is compatible with username/password and enterprise OIDC/SSO/IDaaS integration, while key processes (registration, credential application, subscription) support automatic or manual approval configurations.',
 
     // Product Layout
     'product.layout.enterprise.title': 'Learn about Enterprise Edition',

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -4,6 +4,7 @@ export default {
   "page.header.gateway": "云原生 API 网关",
   "page.header.ai.gateway": "AI 网关",
   "page.header.himarket": "HiMarket",
+  "page.header.hiclaw": "HiClaw",
   "navbar.product": "产品",
   "navbar.product.features": "功能特性",
   "navbar.product.benefits": "核心优势",
@@ -794,6 +795,23 @@ export default {
 
     'himarket.product.extension_capability': '扩展能力',
     'himarket.product.extension_capability.desc': 'HiMarket 提供灵活定制以快速对接企业现有系统。门户支持自定义域名与品牌样式，并可按需配置首页模块与产品分类等。身份认证兼容账号密码与企业 OIDC/SSO/IDaaS 集成，同时关键流程（注册、凭证申请、订阅）支持自动或人工审批配置。',
+
+    // HiClaw Product Page
+    'hiclaw.product.intro.desc': '助力企业构建 Agent、Model、MCP 市场，通过统一的 AI 能力 management 平台，解决 AI 资源分散、权限管控复杂、成本分摊困难等挑战，平台提供 HiChat AI 创新中心作为全员 AI 使用入口，打破团队间的能力孤岛，降低接入成本，释放 AI 创新潜能。',
+    'hiclaw.product.core_features.title': '核心功能',
+    'hiclaw.product.core_features.desc': 'HiClaw 为企业带来开箱即用、快速集成的 AI 能力。',
+
+    'hiclaw.product.ai_market': 'AI 市场',
+    'hiclaw.product.ai_market.desc': '支持构建涵盖 Agent、MCP Server、Model 的完整 AI 市场，让企业的各类 AI 资源不再分散，而是以标准化方式汇聚在一个平台上，形成 AI 能力的统一供给与管理。',
+
+    'hiclaw.product.hichat': 'HiChat',
+    'hiclaw.product.hichat.desc': 'HiChat 以对话替代搜索，覆盖市场/产品调研与运营内容生成，并作为企业全员统一的 AI 使用入口，集中完成多模型选型使用与安全合规管控。平台支持一次输入多模型对比、会话历史沉淀复用，并通过 Higress AI 网关统一开启联网搜索与关联/转换 MCP 工具，实现快速验证与扩展能力。',
+
+    'hiclaw.product.enterprise_capability': '企业级能力',
+    'hiclaw.product.enterprise_capability.desc': '提供企业级管理闭环，管理员可对各 API 产品配置鉴权与可见性，并结合流量控制、IP 白名单等能力保障安全稳定。平台还支持全局观测分析、按 Token/调用次数计量计费，以及多版本并行的灰度发布与快速回滚，支撑高效运营与稳定迭代。',
+
+    'hiclaw.product.extension_capability': '扩展能力',
+    'hiclaw.product.extension_capability.desc': 'HiClaw 提供灵活定制以快速对接企业现有系统。门户支持自定义域名与品牌样式，并可按需配置首页模块与产品分类等。身份认证兼容账号密码与企业 OIDC/SSO/IDaaS 集成，同时关键流程（注册、凭证申请、订阅）支持自动或人工审批配置。',
 
     // Product Layout
     'product.layout.enterprise.title': '了解企业版',

--- a/src/pages/en/hiclaw.astro
+++ b/src/pages/en/hiclaw.astro
@@ -1,0 +1,14 @@
+
+---
+import SiteLayout from "../../layout/siteLayout.astro";
+import HiClaw from "../../container/products/HiClaw.astro";
+import { useTranslations } from "@/i18n/utils";
+const locale = Astro.currentLocale || 'root';
+const t = useTranslations(locale);
+---
+<SiteLayout 
+  title={"HiClaw"} 
+  description={t("hiclaw.product.intro.desc")}
+>
+  <HiClaw />
+</SiteLayout>

--- a/src/pages/hiclaw.astro
+++ b/src/pages/hiclaw.astro
@@ -1,0 +1,53 @@
+---
+import SiteLayout from "../layout/siteLayout.astro";
+import HiClaw from "../container/products/HiClaw.astro";
+import { useTranslations } from "@/i18n/utils";
+const locale = Astro.currentLocale || 'root';
+const t = useTranslations(locale);
+---
+<SiteLayout 
+  title={t("page.header.hiclaw")} 
+  description={t("hiclaw.product.intro.desc")}
+>
+  <HiClaw />
+</SiteLayout>
+
+<!-- Structured Data for SEO -->
+<script type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "HiClaw",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Cross-platform",
+  "description": "助力企业构建 Agent、Model、MCP 市场，通过统一的 AI 能力管理平台，提供 HiChat AI 创新中心作为全员 AI 使用入口",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "USD"
+  },
+  "provider": {
+    "@type": "Organization",
+    "name": "Higress",
+    "url": "https://higress.ai"
+  },
+  "url": "https://higress.ai/hiclaw"
+})} />
+
+<script type="application/ld+json" set:html={JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+    {
+      "@type": "ListItem",
+      "position": 1,
+      "name": "Home",
+      "item": "https://higress.ai/"
+    },
+    {
+      "@type": "ListItem",
+      "position": 2,
+      "name": "HiClaw",
+      "item": "https://higress.ai/hiclaw"
+    }
+  ]
+})} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -69,7 +69,7 @@ site-search {
   --sl-content-width: 100%;
   --sl-nav-height: 4rem;
   --sl-right-sidebar-width: 14rem;
-  /*--sl-sidebar-width: 290px;*/
+  --sl-sidebar-width: 350px;
 }
 
 @theme {

--- a/src/utils/sidebarLoader.ts
+++ b/src/utils/sidebarLoader.ts
@@ -3,17 +3,19 @@ import enSidebarConfig from "../content/docs/en/docs/latest/_sidebar.json";
 import zhAiSidebarConfig from "../content/docs/docs/ai/_sidebar.json";
 import enAiSidebarConfig from "../content/docs/en/docs/ai/_sidebar.json";
 import zhHimarketSidebarConfig from "../content/docs/docs/himarket/_sidebar.json";
+import zhHiclawSidebarConfig from "../content/docs/docs/hiclaw/_sidebar.json";
 import zhDeveloperSidebarConfig from "../content/docs/docs/developers/_sidebar.json";
 import enDeveloperSidebarConfig from "../content/docs/en/docs/developers/_sidebar.json";
 // 暂时没有英文版配置，先用中文的或者空的
 const enHimarketSidebarConfig: any[] = [];
+const enHiclawSidebarConfig: any[] = [];
 
 /**
  * 动态加载指定语言的 sidebar 配置
  */
 function loadSidebarConfigByLocale(
   locale: string,
-  type: "docs" | "ai" | "himarket" | "developer" = "docs",
+  type: "docs" | "ai" | "himarket" | "hiclaw" | "developer" = "docs",
 ) {
   if (type === "ai") {
     // AI 文档配置
@@ -29,6 +31,14 @@ function loadSidebarConfigByLocale(
       return enHimarketSidebarConfig;
     }
     return zhHimarketSidebarConfig;
+  }
+
+  if (type === "hiclaw") {
+    // HiClaw 文档配置
+    if (locale === "en") {
+      return enHiclawSidebarConfig;
+    }
+    return zhHiclawSidebarConfig;
   }
 
   if (type === "developer") {
@@ -54,7 +64,7 @@ function loadSidebarConfigByLocale(
 function transformSidebarItem(
   item: any,
   locale: string = "root",
-  type: "docs" | "ai" | "himarket" | "developer" = "docs",
+  type: "docs" | "ai" | "himarket" | "hiclaw" | "developer" = "docs",
 ): any {
   const transformed: any = {
     label: item.label,
@@ -82,6 +92,15 @@ function transformSidebarItem(
       } else {
         // root locale (中文)
         transformed.link = `docs/himarket/${cleanLink}/`;
+      }
+    } else if (type === "hiclaw") {
+      // HiClaw 文档路径
+      const cleanLink = item.link.replace(/^docs\//, "");
+      if (locale === "en") {
+        transformed.link = `en/docs/hiclaw/${cleanLink}/`;
+      } else {
+        // root locale (中文)
+        transformed.link = `docs/hiclaw/${cleanLink}/`;
       }
     } else if (type === "developer") {
       // HiMarket 文档路径
@@ -136,6 +155,17 @@ function transformSidebarItem(
           directory: `docs/himarket/${item.autogenerate.directory}`,
         };
       }
+    } else if (type === "hiclaw") {
+      // HiClaw 文档自动生成
+      if (locale === "en") {
+        transformed.autogenerate = {
+          directory: `en/docs/hiclaw/${item.autogenerate.directory}`,
+        };
+      } else {
+        transformed.autogenerate = {
+          directory: `docs/hiclaw/${item.autogenerate.directory}`,
+        };
+      }
     } else if (type === "developer") {
       // HiMarket 文档自动生成
       if (locale === "en") {
@@ -187,7 +217,7 @@ function transformSidebarItem(
  */
 export function loadSidebarConfig(
   locale: string = "root",
-  type: "docs" | "ai" | "himarket" = "docs",
+  type: "docs" | "ai" | "himarket" | "hiclaw" | "developer" = "docs",
 ) {
   const sidebarConfig = loadSidebarConfigByLocale(locale, type);
   return sidebarConfig.map((item) => transformSidebarItem(item, locale, type));

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -2,6 +2,7 @@ export const sidebarCategory = {
   latest: "/docs/latest",
   ai: "/ai/",
   himarket: "/docs/himarket",
+  hiclaw: "/docs/hiclaw",
   developer: "/docs/developers",
 }
 
@@ -10,5 +11,6 @@ export const sidebarCategoryDefaultLink = {
   latest: "/docs/latest/overview/what-is-higress",
   ai: "/docs/ai/quick-start",
   himarket: "/docs/himarket/himarket-introduction",
+  hiclaw: "/docs/hiclaw/hiclaw-introduction",
   developer: "/docs/developers/developers_dev",
 }


### PR DESCRIPTION
- 新增 HiClaw 侧边栏配置及页面路由支持
- 在导航栏和页面框架中添加 HiClaw 入口与选项
- 创建 HiClaw 产品展示组件及核心功能介绍页面
- 编写 HiClaw 部署指南，支持本地、Docker Compose、Helm 部署方式
- 增补 HiClaw 产品介绍文档，包含产品优势及使用场景
- 配置多语言支持，包括中英文翻译文本
- 实现页面样式及交互细节优化，提升用户体验

Change-Id: Id8f64f4301d732f3175530b98300a76cf050efda
Co-developed-by: Qoder <noreply@qoder.com>