### PR TITLE
docs(himarket): update deployment guide for new install.sh workflow

### DIFF
--- a/src/content/docs/docs/ai/himarket/himarket-deployment.md
+++ b/src/content/docs/docs/ai/himarket/himarket-deployment.md
@@ -51,117 +51,118 @@ npm run dev
 
 ## 二、基于 Docker Compose 部署
 
-包含七个服务组件：
+包含以下服务组件：
 
-+ **mysql：** 数据库服务，为后端服务提供数据存储；
-+ **himarket-server：** 后端服务，运行在 8081 端口；
-+ **himarket-admin：** 管理后台界面，运行在 5174 端口，供管理员配置 Portal；
-+ **himarket-frontend：** 前台用户界面，运行在 5173 端口，供用户浏览和使用 API Product；
-+ **Higress：** Higress all-in-one 网关服务，运行在 8443、8082、8001 端口，其中控制台运行在 8001 端口，供用户浏览和使用；
++ **MySQL：** 数据库服务，为后端服务和 Nacos 提供数据存储；
++ **Nacos：** 配置中心，运行在 8848 端口；
++ **Higress：** AI 网关服务，控制台运行在 8001 端口，网关 HTTP 入口运行在 8082 端口；
 + **Redis：** Higress 缓存服务；
-+ **Nacos：** Nacos 服务，运行在 8080、8848、9848 端口，其中控制台运行在 8080 端口，供用户浏览和使用。
++ **HiMarket Server：** 后端 API 服务，运行在 8081 端口；
++ **HiMarket Admin：** 管理后台界面，运行在 5175 端口；
++ **HiMarket Frontend：** 开发者门户界面，运行在 5173 端口；
++ **Sandbox：** 远程沙箱服务，支持云 IDE 功能。
 
 ### 安装命令
 
 **环境依赖：** docker、docker compose、curl、jq
 
-**一键拉起：** 使用 `deploy.sh` 脚本完成 HiMarket、Higress、Nacos 全栈部署和数据初始化。
+**交互式部署（推荐）：**
 
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/docker/scripts
+cd himarket/deploy/docker
 
-# 部署全栈服务并初始化
-./deploy.sh install
-
-# 或仅部署 Himarket 服务（不含 Nacos/Higress）
-./deploy.sh himarket-only
-
-# 卸载所有服务
-./deploy.sh uninstall
-
-# 服务地址
-# 管理后台地址：http://localhost:5174
-# 开发者门户地址：http://localhost:5173
-# 后端 API 地址：http://localhost:8081
+# 交互式部署，脚本会逐步引导完成所有配置
+./install.sh
 ```
 
-该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+脚本会引导您完成镜像选择、密码设置、AI 模型配置等所有配置项。首次安装时，数据库密码和服务凭证会自动生成随机值。
+
+**非交互模式（CI/CD）：**
 
 ```bash
-cd docker/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install-docker.env
+# 编辑 ~/himarket-install-docker.env 按需修改配置
+./install.sh -n
+```
 
-# 重试失败脚本
+**卸载：**
+
+```bash
+./install.sh --uninstall
+```
+
+**升级：**
+
+重新运行 `./install.sh`，脚本会自动检测已有部署并提供升级选项。配置自动保存到 `~/himarket-install-docker.env`，升级时自动复用。
+
+**重试数据初始化：**
+
+```bash
+# 仅重试初始化钩子，不重新部署服务
+./install.sh --init-data
+
+# 或手动执行单个钩子
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
+### 服务端口
+
+| 服务 | 主机端口 | 说明 |
+|------|---------|------|
+| HiMarket Frontend | 5173 | 开发者门户界面 |
+| HiMarket Admin | 5175 | 管理后台界面 |
+| HiMarket Server | 8081 | 后端 API 服务 |
+| Nacos | 8848 | Nacos 控制台 |
+| Higress Console | 8001 | Higress 控制台 |
+| Higress Gateway | 8082 | 网关 HTTP 入口 |
+| MySQL | 3306 | 数据库服务 |
+| Redis | 6379 | Redis 服务 |
+
 ### 安装配置
 
-所有配置集中在 `scripts/data/.env` 文件中：
+配置文件为 `~/himarket-install-docker.env`（交互模式下自动生成），也可从 `.env.example` 模板复制。主要配置项：
 
-```bash
-cd docker/scripts/data
-vi .env
-```
-
-| 配置名 | 配置说明 | **默认值** |
+| 配置名 | 配置说明 | 默认值 |
 | --- | --- | --- |
-| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 123456 |
-| MYSQL_DATABASE | MySQL 数据库名 | portal_db |
-| MYSQL_USER | MySQL 用户名 | portal_user |
-| MYSQL_PASSWORD | MySQL 密码 | portal_pass |
-| USE_BUILTIN_MYSQL | 是否使用内置 MySQL（true/false） | true |
-| DB_HOST | 数据库地址（使用外置数据库时必填） | mysql |
-| DB_PORT | 数据库端口（使用外置数据库时必填） | 3306 |
-| DB_NAME | 数据库名称（使用外置数据库时必填） | portal_db |
-| DB_USERNAME | 数据库用户名（使用外置数据库时必填） | portal_user |
-| DB_PASSWORD | 数据库密码（使用外置数据库时必填） | portal_pass |
-| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
-| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
-| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
-| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
-| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
-| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
-| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
-| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
-| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
-| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
-| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
-| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| HIMARKET_SERVER_IMAGE | HiMarket 后端服务镜像 | opensource-registry...himarket-server:latest |
+| HIMARKET_ADMIN_IMAGE | HiMarket 管理后台镜像 | opensource-registry...himarket-admin:latest |
+| HIMARKET_FRONTEND_IMAGE | HiMarket 前台服务镜像 | opensource-registry...himarket-frontend:latest |
+| MYSQL_IMAGE | MySQL 镜像地址 | opensource-registry...mysql:latest |
+| NACOS_IMAGE | Nacos 镜像地址 | nacos-registry...nacos-server:v3.2.1-2026.03.30 |
+| HIGRESS_IMAGE | Higress 镜像地址 | higress-registry...all-in-one:latest |
+| REDIS_IMAGE | Redis 镜像地址 | higress-registry...redis-stack-server:7.4.0-v3 |
+| SANDBOX_IMAGE | Sandbox 镜像地址 | opensource-registry...sandbox:latest |
+| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 自动生成 |
+| MYSQL_PASSWORD | MySQL 应用密码 | 自动生成 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | 自动生成 |
 | HIGRESS_USERNAME | Higress 登录用户名 | admin |
-| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | 自动生成 |
 | ADMIN_USERNAME | 后台管理员用户名 | admin |
-| ADMIN_PASSWORD | 后台管理员密码 | admin |
-| FRONT_USERNAME | 前台默认用户名 | demo |
-| FRONT_PASSWORD | 前台默认密码 | demo123 |
-| NACOS_IMAGE | Nacos 镜像地址 | nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.1.1 |
-| NACOS_AUTH_IDENTITY_KEY | Nacos 认证身份标识 Key | serverIdentity |
-| NACOS_AUTH_IDENTITY_VALUE | Nacos 认证身份标识 Value | security |
-| NACOS_AUTH_TOKEN | Nacos 认证 Token | VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg= |
-| HIGRESS_IMAGE | Higress 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest |
-| HIMARKET_SERVER_IMAGE | Himarket 后端服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-server:latest |
-| HIMARKET_ADMIN_IMAGE | Himarket 管理后台镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-admin:latest |
-| HIMARKET_FRONTEND_IMAGE | Himarket 前台服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-frontend:latest |
-| REDIS_IMAGE | Redis 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3 |
-| MYSQL_IMAGE | MySQL 镜像地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest |
+| ADMIN_PASSWORD | 后台管理员密码 | 自动生成 |
+| FRONT_USERNAME | 前台默认用户名 | user |
+| FRONT_PASSWORD | 前台默认密码 | 自动生成 |
+| SKIP_AI_MODEL_INIT | 是否跳过 AI 模型初始化 | true |
+| AI_MODEL_COUNT | AI 模型数量 | 0 |
 
+> 完整配置项请参考 `.env.example` 文件。日志文件位于 `~/himarket-install-docker.log`。
 
 ## 三、使用 Helm 进行云原生部署
 
-Helm 是一个用于自动化管理和发布 Kubernetes 软件的包管理系统。通过 Helm 一键部署脚本您可以在 Kubernetes 集群上快速部署安装 HiMarkt+Higress+Nacos，包含十个服务组件：
+Helm 是 Kubernetes 的包管理工具。通过 `install.sh` 脚本可在 K8s 集群上一键部署 HiMarket + Higress + Nacos 全栈服务，包含以下组件：
 
 + **HiMarket：**
-    - himarket-server：Himarket AI 开放平台的后端服务；
-    - himarket-admin：Himarket AI 开放平台管理后台，管理员通过此界面配置 Portal；
-    - himarket-frontend：Himarket AI 开放平台的前台服务，用户通过此界面浏览和使用 API；
-    - mysql：可选内置数据库。
+    - himarket-server：后端 API 服务；
+    - himarket-admin：管理后台界面；
+    - himarket-frontend：开发者门户界面；
+    - mysql：可选内置数据库；
+    - sandbox-shared：远程沙箱服务。
 + **Higress：**
-    - higress-console：控制台，用户通过此界面浏览和使用 Higress 服务；
-    - higress-controller：控制面组件，负责管理配置下发；
-    - higress-gateway：数据面组件，负责承载数据流量；
+    - higress-console：Higress 控制台；
+    - higress-controller：控制面组件；
+    - higress-gateway：数据面组件；
     - redis-stack-server：缓存组件。
 + **Nacos：**
     - nacos：Nacos 应用；
@@ -169,97 +170,81 @@ Helm 是一个用于自动化管理和发布 Kubernetes 软件的包管理系统
 
 **服务类型说明：**
 
-默认为 LoadBalancer 类型服务，适用于云环境（阿里云 ACK、AWS EKS 等）。如果您的环境不支持 LoadBalancer（如本地 minikube、自建集群），可以使用 NodePort 或端口转发方式访问。后台配置好 Himarket 后，将域名解析到 himarket-frontend 服务的访问地址，用户就可以通过域名访问前台站点。
+默认为 LoadBalancer 类型服务，适用于云环境（阿里云 ACK、AWS EKS 等）。如果您的环境不支持 LoadBalancer（如本地 minikube、自建集群），可以使用 NodePort 或端口转发方式访问。
 
 ### 安装命令
 
-**环境依赖：** kubectl、python3/python、curl、jq
+**环境依赖：** kubectl（已连接 K8s 集群）、helm、curl、jq、python3
 
-**一键拉起：** 使用 `deploy.sh` 脚本将 HiMarket 部署到 Kubernetes 集群。
+**交互式部署（推荐）：**
 
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/helm/scripts
+cd himarket/deploy/helm
 
-# 部署全栈服务并初始化
-./deploy.sh install
-
-# 或仅部署 Himarket 服务（不含 Nacos/Higress）
-./deploy.sh himarket-only
-
-# 卸载
-./deploy.sh uninstall
+# 交互式部署
+./install.sh
 ```
 
-该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+**非交互模式（CI/CD）：**
 
 ```bash
-cd helm/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install.env
+# 编辑 ~/himarket-install.env 按需修改配置
+./install.sh -n
+```
 
-# 重试失败脚本
+**卸载：**
+
+```bash
+./install.sh --uninstall
+```
+
+**升级：**
+
+重新运行 `./install.sh`，脚本会自动检测已有部署并提供升级选项。配置自动保存到 `~/himarket-install.env`，升级时自动复用。
+
+**重试数据初始化：**
+
+```bash
+# 仅重试初始化钩子，不重新部署服务
+./install.sh --init-data
+
+# 或手动执行单个钩子
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
 ### 安装配置
 
-相关配置集中在 `scripts/data/.env` 文件中：
+配置文件为 `~/himarket-install.env`（交互模式下自动生成），也可从 `.env.example` 模板复制。主要配置项：
 
-```bash
-cd helm/scripts/data
-vi .env
-```
-
-| 配置名 | 配置说明 | **默认值** |
+| 配置名 | 配置说明 | 默认值 |
 | --- | --- | --- |
-| NAMESPACE | Kubernetes 命名空间 | himarket-system |
-| HIMARKET_ONLY | 仅部署 Himarket（跳过 Nacos/Higress） | false |
-| HIMARKET_IMAGE_TAG | Himarket 镜像标签 | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
-| HIMARKET_MYSQL_ENABLED | 是否使用内置 MySQL（true/false） | true |
-| EXTERNAL_DB_HOST | 外部数据库地址（HIMARKET_MYSQL_ENABLED=false 时使用） | Your_External_DB_Host |
-| EXTERNAL_DB_PORT | 外部数据库端口 | 3306 |
-| EXTERNAL_DB_NAME | 外部数据库名称 | Your_DB_Name |
-| EXTERNAL_DB_USERNAME | 外部数据库用户名 | Your_DB_Username |
-| EXTERNAL_DB_PASSWORD | 外部数据库密码 | Your_DB_Password |
-| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
-| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
-| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
-| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
-| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
-| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
-| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
-| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
-| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
-| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
-| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
-| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| NAMESPACE | Kubernetes 命名空间 | himarket |
+| HIMARKET_HUB | HiMarket 镜像仓库地址 | opensource-registry...higress-group |
+| HIMARKET_IMAGE_TAG | HiMarket 镜像标签 | latest |
+| NACOS_VERSION | Nacos 镜像版本 | v3.2.1-2026.03.30 |
+| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 自动生成 |
+| MYSQL_PASSWORD | MySQL 应用密码 | 自动生成 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | 自动生成 |
 | HIGRESS_USERNAME | Higress 登录用户名 | admin |
-| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | 自动生成 |
 | ADMIN_USERNAME | 后台管理员用户名 | admin |
-| ADMIN_PASSWORD | 后台管理员密码 | admin |
-| FRONT_USERNAME | 前台默认用户名 | demo |
-| FRONT_PASSWORD | 前台默认密码 | demo123 |
-| NACOS_VERSION | Nacos 镜像版本 | v3.1.1 |
-| NACOS_IMAGE_REGISTRY | Nacos 镜像仓库 | nacos-registry.cn-hangzhou.cr.aliyuncs.com |
-| NACOS_IMAGE_REPOSITORY | Nacos 镜像地址 | nacos/nacos-server |
-| HIGRESS_REPO_NAME | Higress Helm 仓库名称 | higress.io |
-| HIGRESS_REPO_URL | Higress Helm 仓库地址 | https://higress.cn/helm-charts |
-| HIGRESS_CHART_REF | Higress Chart 引用 | higress.io/higress |
-| NACOS_REPO_NAME | Nacos Helm 仓库名称 | ygqygq2 |
-| NACOS_REPO_URL | Nacos Helm 仓库地址 | https://ygqygq2.github.io/charts/ |
-| NACOS_CHART_REF | Nacos Chart 引用 | ygqygq2/nacos |
-| HIMARKET_HUB | Himarket 镜像仓库地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group |
-| HIMARKET_IMAGE_TAG | Himarket 镜像标签 | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
+| ADMIN_PASSWORD | 后台管理员密码 | 自动生成 |
+| FRONT_USERNAME | 前台默认用户名 | user |
+| FRONT_PASSWORD | 前台默认密码 | 自动生成 |
+| MYSQL_STORAGE_CLASS | MySQL 存储类 | alicloud-disk-essd |
+| MYSQL_STORAGE_SIZE | MySQL 存储大小 | 50Gi |
+| SANDBOX_STORAGE_CLASS | Sandbox 存储类 | alicloud-disk-essd |
+| SANDBOX_STORAGE_SIZE | Sandbox 存储大小 | 50Gi |
+| HIGRESS_INGRESS_CLASS | Higress IngressClass | himarket |
+| SKIP_AI_MODEL_INIT | 是否跳过 AI 模型初始化 | true |
+| AI_MODEL_COUNT | AI 模型数量 | 0 |
 
-
-注：Himarket 的 Helm 包适配阿里云 ACK 集群使用，/helm/values.yaml 文件下存储类 persistence.storageClass: "alicloud-disk-essd"  值需根据实际环境调整。
+> 完整配置项请参考 `.env.example` 文件。存储类 `MYSQL_STORAGE_CLASS` 和 `SANDBOX_STORAGE_CLASS` 需根据实际 K8s 环境调整。日志文件位于 `~/himarket-install.log`。
 
 ## 四、云平台部署（阿里云）
 
 阿里云计算巢支持该项目的开箱即用版本，可一键部署社区版：[![Deploy on AlibabaCloud ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest.svg)](https://computenest.console.aliyun.com/service/instance/create/cn-hangzhou?type=user&ServiceId=service-b96fefcb748f47b7b958)
-
-

--- a/src/content/docs/docs/himarket/himarket-deployment.md
+++ b/src/content/docs/docs/himarket/himarket-deployment.md
@@ -51,117 +51,118 @@ npm run dev
 
 ## 二、基于 Docker Compose 部署
 
-包含七个服务组件：
+包含以下服务组件：
 
-+ **mysql：** 数据库服务，为后端服务提供数据存储；
-+ **himarket-server：** 后端服务，运行在 8081 端口；
-+ **himarket-admin：** 管理后台界面，运行在 5174 端口，供管理员配置 Portal；
-+ **himarket-frontend：** 前台用户界面，运行在 5173 端口，供用户浏览和使用 API Product；
-+ **Higress：** Higress all-in-one 网关服务，运行在 8443、8082、8001 端口，其中控制台运行在 8001 端口，供用户浏览和使用；
++ **MySQL：** 数据库服务，为后端服务和 Nacos 提供数据存储；
++ **Nacos：** 配置中心，运行在 8848 端口；
++ **Higress：** AI 网关服务，控制台运行在 8001 端口，网关 HTTP 入口运行在 8082 端口；
 + **Redis：** Higress 缓存服务；
-+ **Nacos：** Nacos 服务，运行在 8080、8848、9848 端口，其中控制台运行在 8080 端口，供用户浏览和使用。
++ **HiMarket Server：** 后端 API 服务，运行在 8081 端口；
++ **HiMarket Admin：** 管理后台界面，运行在 5175 端口；
++ **HiMarket Frontend：** 开发者门户界面，运行在 5173 端口；
++ **Sandbox：** 远程沙箱服务，支持云 IDE 功能。
 
 ### 安装命令
 
 **环境依赖：** docker、docker compose、curl、jq
 
-**一键拉起：** 使用 `deploy.sh` 脚本完成 HiMarket、Higress、Nacos 全栈部署和数据初始化。
+**交互式部署（推荐）：**
 
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/docker/scripts
+cd himarket/deploy/docker
 
-# 部署全栈服务并初始化
-./deploy.sh install
-
-# 或仅部署 Himarket 服务（不含 Nacos/Higress）
-./deploy.sh himarket-only
-
-# 卸载所有服务
-./deploy.sh uninstall
-
-# 服务地址
-# 管理后台地址：http://localhost:5174
-# 开发者门户地址：http://localhost:5173
-# 后端 API 地址：http://localhost:8081
+# 交互式部署，脚本会逐步引导完成所有配置
+./install.sh
 ```
 
-该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+脚本会引导您完成镜像选择、密码设置、AI 模型配置等所有配置项。首次安装时，数据库密码和服务凭证会自动生成随机值。
+
+**非交互模式（CI/CD）：**
 
 ```bash
-cd docker/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install-docker.env
+# 编辑 ~/himarket-install-docker.env 按需修改配置
+./install.sh -n
+```
 
-# 重试失败脚本
+**卸载：**
+
+```bash
+./install.sh --uninstall
+```
+
+**升级：**
+
+重新运行 `./install.sh`，脚本会自动检测已有部署并提供升级选项。配置自动保存到 `~/himarket-install-docker.env`，升级时自动复用。
+
+**重试数据初始化：**
+
+```bash
+# 仅重试初始化钩子，不重新部署服务
+./install.sh --init-data
+
+# 或手动执行单个钩子
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
+### 服务端口
+
+| 服务 | 主机端口 | 说明 |
+|------|---------|------|
+| HiMarket Frontend | 5173 | 开发者门户界面 |
+| HiMarket Admin | 5175 | 管理后台界面 |
+| HiMarket Server | 8081 | 后端 API 服务 |
+| Nacos | 8848 | Nacos 控制台 |
+| Higress Console | 8001 | Higress 控制台 |
+| Higress Gateway | 8082 | 网关 HTTP 入口 |
+| MySQL | 3306 | 数据库服务 |
+| Redis | 6379 | Redis 服务 |
+
 ### 安装配置
 
-所有配置集中在 `scripts/data/.env` 文件中：
+配置文件为 `~/himarket-install-docker.env`（交互模式下自动生成），也可从 `.env.example` 模板复制。主要配置项：
 
-```bash
-cd docker/scripts/data
-vi .env
-```
-
-| 配置名 | 配置说明 | **默认值** |
+| 配置名 | 配置说明 | 默认值 |
 | --- | --- | --- |
-| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 123456 |
-| MYSQL_DATABASE | MySQL 数据库名 | portal_db |
-| MYSQL_USER | MySQL 用户名 | portal_user |
-| MYSQL_PASSWORD | MySQL 密码 | portal_pass |
-| USE_BUILTIN_MYSQL | 是否使用内置 MySQL（true/false） | true |
-| DB_HOST | 数据库地址（使用外置数据库时必填） | mysql |
-| DB_PORT | 数据库端口（使用外置数据库时必填） | 3306 |
-| DB_NAME | 数据库名称（使用外置数据库时必填） | portal_db |
-| DB_USERNAME | 数据库用户名（使用外置数据库时必填） | portal_user |
-| DB_PASSWORD | 数据库密码（使用外置数据库时必填） | portal_pass |
-| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
-| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
-| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
-| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
-| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
-| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
-| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
-| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
-| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
-| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
-| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
-| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| HIMARKET_SERVER_IMAGE | HiMarket 后端服务镜像 | opensource-registry...himarket-server:latest |
+| HIMARKET_ADMIN_IMAGE | HiMarket 管理后台镜像 | opensource-registry...himarket-admin:latest |
+| HIMARKET_FRONTEND_IMAGE | HiMarket 前台服务镜像 | opensource-registry...himarket-frontend:latest |
+| MYSQL_IMAGE | MySQL 镜像地址 | opensource-registry...mysql:latest |
+| NACOS_IMAGE | Nacos 镜像地址 | nacos-registry...nacos-server:v3.2.1-2026.03.30 |
+| HIGRESS_IMAGE | Higress 镜像地址 | higress-registry...all-in-one:latest |
+| REDIS_IMAGE | Redis 镜像地址 | higress-registry...redis-stack-server:7.4.0-v3 |
+| SANDBOX_IMAGE | Sandbox 镜像地址 | opensource-registry...sandbox:latest |
+| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 自动生成 |
+| MYSQL_PASSWORD | MySQL 应用密码 | 自动生成 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | 自动生成 |
 | HIGRESS_USERNAME | Higress 登录用户名 | admin |
-| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | 自动生成 |
 | ADMIN_USERNAME | 后台管理员用户名 | admin |
-| ADMIN_PASSWORD | 后台管理员密码 | admin |
-| FRONT_USERNAME | 前台默认用户名 | demo |
-| FRONT_PASSWORD | 前台默认密码 | demo123 |
-| NACOS_IMAGE | Nacos 镜像地址 | nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.1.1 |
-| NACOS_AUTH_IDENTITY_KEY | Nacos 认证身份标识 Key | serverIdentity |
-| NACOS_AUTH_IDENTITY_VALUE | Nacos 认证身份标识 Value | security |
-| NACOS_AUTH_TOKEN | Nacos 认证 Token | VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg= |
-| HIGRESS_IMAGE | Higress 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest |
-| HIMARKET_SERVER_IMAGE | Himarket 后端服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-server:latest |
-| HIMARKET_ADMIN_IMAGE | Himarket 管理后台镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-admin:latest |
-| HIMARKET_FRONTEND_IMAGE | Himarket 前台服务镜像 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-frontend:latest |
-| REDIS_IMAGE | Redis 镜像地址 | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3 |
-| MYSQL_IMAGE | MySQL 镜像地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest |
+| ADMIN_PASSWORD | 后台管理员密码 | 自动生成 |
+| FRONT_USERNAME | 前台默认用户名 | user |
+| FRONT_PASSWORD | 前台默认密码 | 自动生成 |
+| SKIP_AI_MODEL_INIT | 是否跳过 AI 模型初始化 | true |
+| AI_MODEL_COUNT | AI 模型数量 | 0 |
 
+> 完整配置项请参考 `.env.example` 文件。日志文件位于 `~/himarket-install-docker.log`。
 
 ## 三、使用 Helm 进行云原生部署
 
-Helm 是一个用于自动化管理和发布 Kubernetes 软件的包管理系统。通过 Helm 一键部署脚本您可以在 Kubernetes 集群上快速部署安装 HiMarkt+Higress+Nacos，包含十个服务组件：
+Helm 是 Kubernetes 的包管理工具。通过 `install.sh` 脚本可在 K8s 集群上一键部署 HiMarket + Higress + Nacos 全栈服务，包含以下组件：
 
 + **HiMarket：**
-    - himarket-server：Himarket AI 开放平台的后端服务；
-    - himarket-admin：Himarket AI 开放平台管理后台，管理员通过此界面配置 Portal；
-    - himarket-frontend：Himarket AI 开放平台的前台服务，用户通过此界面浏览和使用 API；
-    - mysql：可选内置数据库。
+    - himarket-server：后端 API 服务；
+    - himarket-admin：管理后台界面；
+    - himarket-frontend：开发者门户界面；
+    - mysql：可选内置数据库；
+    - sandbox-shared：远程沙箱服务。
 + **Higress：**
-    - higress-console：控制台，用户通过此界面浏览和使用 Higress 服务；
-    - higress-controller：控制面组件，负责管理配置下发；
-    - higress-gateway：数据面组件，负责承载数据流量；
+    - higress-console：Higress 控制台；
+    - higress-controller：控制面组件；
+    - higress-gateway：数据面组件；
     - redis-stack-server：缓存组件。
 + **Nacos：**
     - nacos：Nacos 应用；
@@ -169,97 +170,81 @@ Helm 是一个用于自动化管理和发布 Kubernetes 软件的包管理系统
 
 **服务类型说明：**
 
-默认为 LoadBalancer 类型服务，适用于云环境（阿里云 ACK、AWS EKS 等）。如果您的环境不支持 LoadBalancer（如本地 minikube、自建集群），可以使用 NodePort 或端口转发方式访问。后台配置好 Himarket 后，将域名解析到 himarket-frontend 服务的访问地址，用户就可以通过域名访问前台站点。
+默认为 LoadBalancer 类型服务，适用于云环境（阿里云 ACK、AWS EKS 等）。如果您的环境不支持 LoadBalancer（如本地 minikube、自建集群），可以使用 NodePort 或端口转发方式访问。
 
 ### 安装命令
 
-**环境依赖：** kubectl、python3/python、curl、jq
+**环境依赖：** kubectl（已连接 K8s 集群）、helm、curl、jq、python3
 
-**一键拉起：** 使用 `deploy.sh` 脚本将 HiMarket 部署到 Kubernetes 集群。
+**交互式部署（推荐）：**
 
 ```bash
 # 克隆项目
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/helm/scripts
+cd himarket/deploy/helm
 
-# 部署全栈服务并初始化
-./deploy.sh install
-
-# 或仅部署 Himarket 服务（不含 Nacos/Higress）
-./deploy.sh himarket-only
-
-# 卸载
-./deploy.sh uninstall
+# 交互式部署
+./install.sh
 ```
 
-该脚本在部署完后会**执行数据初始化钩子**：执行登录数据初始化、示例 MCP 数据初始化、API 产品数据初始化。注意脚本包含**部署**和**数据初始化**两部分，数据初始化执行不阻塞部署，如若数据初始化钩子失败，可在 `/scripts/hooks/post_ready.d` 下重试。如：
+**非交互模式（CI/CD）：**
 
 ```bash
-cd helm/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install.env
+# 编辑 ~/himarket-install.env 按需修改配置
+./install.sh -n
+```
 
-# 重试失败脚本
+**卸载：**
+
+```bash
+./install.sh --uninstall
+```
+
+**升级：**
+
+重新运行 `./install.sh`，脚本会自动检测已有部署并提供升级选项。配置自动保存到 `~/himarket-install.env`，升级时自动复用。
+
+**重试数据初始化：**
+
+```bash
+# 仅重试初始化钩子，不重新部署服务
+./install.sh --init-data
+
+# 或手动执行单个钩子
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
 ### 安装配置
 
-相关配置集中在 `scripts/data/.env` 文件中：
+配置文件为 `~/himarket-install.env`（交互模式下自动生成），也可从 `.env.example` 模板复制。主要配置项：
 
-```bash
-cd helm/scripts/data
-vi .env
-```
-
-| 配置名 | 配置说明 | **默认值** |
+| 配置名 | 配置说明 | 默认值 |
 | --- | --- | --- |
-| NAMESPACE | Kubernetes 命名空间 | himarket-system |
-| HIMARKET_ONLY | 仅部署 Himarket（跳过 Nacos/Higress） | false |
-| HIMARKET_IMAGE_TAG | Himarket 镜像标签 | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
-| HIMARKET_MYSQL_ENABLED | 是否使用内置 MySQL（true/false） | true |
-| EXTERNAL_DB_HOST | 外部数据库地址（HIMARKET_MYSQL_ENABLED=false 时使用） | Your_External_DB_Host |
-| EXTERNAL_DB_PORT | 外部数据库端口 | 3306 |
-| EXTERNAL_DB_NAME | 外部数据库名称 | Your_DB_Name |
-| EXTERNAL_DB_USERNAME | 外部数据库用户名 | Your_DB_Username |
-| EXTERNAL_DB_PASSWORD | 外部数据库密码 | Your_DB_Password |
-| USE_COMMERCIAL_NACOS | 是否使用商业化 Nacos（true/false），如若使用则跳过部署 Nacos | false |
-| COMMERCIAL_NACOS_NAME | 商业化 Nacos 实例名称 | 空 |
-| COMMERCIAL_NACOS_SERVER_URL | 商业化 Nacos 服务地址 | 空 |
-| COMMERCIAL_NACOS_USERNAME | 商业化 Nacos 用户名（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_PASSWORD | 商业化 Nacos 密码（如需进行商业化 Nacos MCP 数据导入，必填） | 空 |
-| COMMERCIAL_NACOS_ACCESS_KEY | 商业化 Nacos AccessKey | 空 |
-| COMMERCIAL_NACOS_SECRET_KEY | 商业化 Nacos SecretKey | 空 |
-| USE_AI_GATEWAY | 是否使用 AI 网关（true/false），如若使用则跳过部署 Higress 及相关数据初始化脚本 | false |
-| AI_GATEWAY_ID | AI 网关实例 ID | 空 |
-| AI_GATEWAY_NAME | AI 网关实例名称 | 空 |
-| AI_GATEWAY_REGION | AI 网关所在地域 | 空 |
-| AI_GATEWAY_ACCESS_KEY | AI 网关 AccessKey | 空 |
-| AI_GATEWAY_SECRET_KEY | AI 网关 SecretKey | 空 |
-| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | nacos |
+| NAMESPACE | Kubernetes 命名空间 | himarket |
+| HIMARKET_HUB | HiMarket 镜像仓库地址 | opensource-registry...higress-group |
+| HIMARKET_IMAGE_TAG | HiMarket 镜像标签 | latest |
+| NACOS_VERSION | Nacos 镜像版本 | v3.2.1-2026.03.30 |
+| MYSQL_ROOT_PASSWORD | MySQL Root 密码 | 自动生成 |
+| MYSQL_PASSWORD | MySQL 应用密码 | 自动生成 |
+| NACOS_ADMIN_PASSWORD | Nacos 管理员密码 | 自动生成 |
 | HIGRESS_USERNAME | Higress 登录用户名 | admin |
-| HIGRESS_PASSWORD | Higress 登录密码 | admin |
+| HIGRESS_PASSWORD | Higress 登录密码 | 自动生成 |
 | ADMIN_USERNAME | 后台管理员用户名 | admin |
-| ADMIN_PASSWORD | 后台管理员密码 | admin |
-| FRONT_USERNAME | 前台默认用户名 | demo |
-| FRONT_PASSWORD | 前台默认密码 | demo123 |
-| NACOS_VERSION | Nacos 镜像版本 | v3.1.1 |
-| NACOS_IMAGE_REGISTRY | Nacos 镜像仓库 | nacos-registry.cn-hangzhou.cr.aliyuncs.com |
-| NACOS_IMAGE_REPOSITORY | Nacos 镜像地址 | nacos/nacos-server |
-| HIGRESS_REPO_NAME | Higress Helm 仓库名称 | higress.io |
-| HIGRESS_REPO_URL | Higress Helm 仓库地址 | https://higress.cn/helm-charts |
-| HIGRESS_CHART_REF | Higress Chart 引用 | higress.io/higress |
-| NACOS_REPO_NAME | Nacos Helm 仓库名称 | ygqygq2 |
-| NACOS_REPO_URL | Nacos Helm 仓库地址 | https://ygqygq2.github.io/charts/ |
-| NACOS_CHART_REF | Nacos Chart 引用 | ygqygq2/nacos |
-| HIMARKET_HUB | Himarket 镜像仓库地址 | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group |
-| HIMARKET_IMAGE_TAG | Himarket 镜像标签 | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL 镜像标签 | latest |
+| ADMIN_PASSWORD | 后台管理员密码 | 自动生成 |
+| FRONT_USERNAME | 前台默认用户名 | user |
+| FRONT_PASSWORD | 前台默认密码 | 自动生成 |
+| MYSQL_STORAGE_CLASS | MySQL 存储类 | alicloud-disk-essd |
+| MYSQL_STORAGE_SIZE | MySQL 存储大小 | 50Gi |
+| SANDBOX_STORAGE_CLASS | Sandbox 存储类 | alicloud-disk-essd |
+| SANDBOX_STORAGE_SIZE | Sandbox 存储大小 | 50Gi |
+| HIGRESS_INGRESS_CLASS | Higress IngressClass | himarket |
+| SKIP_AI_MODEL_INIT | 是否跳过 AI 模型初始化 | true |
+| AI_MODEL_COUNT | AI 模型数量 | 0 |
 
-
-注：Himarket 的 Helm 包适配阿里云 ACK 集群使用，/helm/values.yaml 文件下存储类 persistence.storageClass: "alicloud-disk-essd"  值需根据实际环境调整。
+> 完整配置项请参考 `.env.example` 文件。存储类 `MYSQL_STORAGE_CLASS` 和 `SANDBOX_STORAGE_CLASS` 需根据实际 K8s 环境调整。日志文件位于 `~/himarket-install.log`。
 
 ## 四、云平台部署（阿里云）
 
 阿里云计算巢支持该项目的开箱即用版本，可一键部署社区版：[![Deploy on AlibabaCloud ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest.svg)](https://computenest.console.aliyun.com/service/instance/create/cn-hangzhou?type=user&ServiceId=service-b96fefcb748f47b7b958)
-
-

--- a/src/content/docs/en/docs/ai/himarket/himarket-deployment.md
+++ b/src/content/docs/en/docs/ai/himarket/himarket-deployment.md
@@ -51,117 +51,118 @@ npm run dev
 
 ## 2. Docker Compose Deployment
 
-Includes seven service components:
+Includes the following service components:
 
-+ **mysql:** Database service, providing data storage for backend services;
-+ **himarket-server:** Backend service, running on port 8081;
-+ **himarket-admin:** Management console interface, running on port 5174, for administrators to configure Portal;
-+ **himarket-frontend:** Frontend user interface, running on port 5173, for users to browse and use API Products;
-+ **Higress:** Higress all-in-one gateway service, running on ports 8443, 8082, 8001, with console running on port 8001 for user access;
++ **MySQL:** Database service, providing data storage for backend services and Nacos;
++ **Nacos:** Configuration center, running on port 8848;
++ **Higress:** AI gateway service, console running on port 8001, gateway HTTP endpoint on port 8082;
 + **Redis:** Higress cache service;
-+ **Nacos:** Nacos service, running on ports 8080, 8848, 9848, with console running on port 8080 for user access.
++ **HiMarket Server:** Backend API service, running on port 8081;
++ **HiMarket Admin:** Management console interface, running on port 5175;
++ **HiMarket Frontend:** Developer portal interface, running on port 5173;
++ **Sandbox:** Remote sandbox service for cloud IDE functionality.
 
 ### Installation Commands
 
 **Environment Dependencies:** docker, docker compose, curl, jq
 
-**One-Click Startup:** Use the `deploy.sh` script to complete full-stack deployment and data initialization of HiMarket, Higress, and Nacos.
+**Interactive Deployment (Recommended):**
 
 ```bash
 # Clone project
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/docker/scripts
+cd himarket/deploy/docker
 
-# Deploy full-stack services and initialize
-./deploy.sh install
-
-# Or deploy only Himarket services (without Nacos/Higress)
-./deploy.sh himarket-only
-
-# Uninstall all services
-./deploy.sh uninstall
-
-# Service addresses
-# Management console address: http://localhost:5174
-# Developer portal address: http://localhost:5173
-# Backend API address: http://localhost:8081
+# Interactive deployment, the script guides you through all configurations
+./install.sh
 ```
 
-The script will **execute data initialization hooks** after deployment: performs login data initialization, example MCP data initialization, and API product data initialization. Note that the script includes **deployment** and **data initialization** parts. Data initialization execution does not block deployment. If data initialization hooks fail, they can be retried in `/scripts/hooks/post_ready.d`. For example:
+The script guides you through image selection, password setup, AI model configuration, and more. On first install, database passwords and service credentials are automatically generated with random values.
+
+**Non-Interactive Mode (CI/CD):**
 
 ```bash
-cd docker/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install-docker.env
+# Edit ~/himarket-install-docker.env to modify configurations as needed
+./install.sh -n
+```
 
-# Retry failed script
+**Uninstall:**
+
+```bash
+./install.sh --uninstall
+```
+
+**Upgrade:**
+
+Re-run `./install.sh`, and the script will automatically detect existing deployments and provide upgrade options. Configurations are saved to `~/himarket-install-docker.env` and reused for subsequent upgrades.
+
+**Retry Data Initialization:**
+
+```bash
+# Retry initialization hooks only, without redeploying services
+./install.sh --init-data
+
+# Or manually execute individual hooks
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
+### Service Ports
+
+| Service | Host Port | Description |
+|---------|-----------|-------------|
+| HiMarket Frontend | 5173 | Developer portal UI |
+| HiMarket Admin | 5175 | Management console UI |
+| HiMarket Server | 8081 | Backend API service |
+| Nacos | 8848 | Nacos console |
+| Higress Console | 8001 | Higress console |
+| Higress Gateway | 8082 | Gateway HTTP endpoint |
+| MySQL | 3306 | Database service |
+| Redis | 6379 | Redis service |
+
 ### Installation Configuration
 
-All configurations are centralized in the `scripts/data/.env` file:
+The configuration file is `~/himarket-install-docker.env` (auto-generated in interactive mode), or can be copied from the `.env.example` template. Key configuration items:
 
-```bash
-cd docker/scripts/data
-vi .env
-```
-
-| Configuration Name | Configuration Description | **Default Value** |
+| Configuration Name | Description | Default Value |
 | --- | --- | --- |
-| MYSQL_ROOT_PASSWORD | MySQL Root password | 123456 |
-| MYSQL_DATABASE | MySQL database name | portal_db |
-| MYSQL_USER | MySQL username | portal_user |
-| MYSQL_PASSWORD | MySQL password | portal_pass |
-| USE_BUILTIN_MYSQL | Whether to use built-in MySQL (true/false) | true |
-| DB_HOST | Database address (required when using external database) | mysql |
-| DB_PORT | Database port (required when using external database) | 3306 |
-| DB_NAME | Database name (required when using external database) | portal_db |
-| DB_USERNAME | Database username (required when using external database) | portal_user |
-| DB_PASSWORD | Database password (required when using external database) | portal_pass |
-| USE_COMMERCIAL_NACOS | Whether to use commercial Nacos (true/false), skips Nacos deployment if used | false |
-| COMMERCIAL_NACOS_NAME | Commercial Nacos instance name | Empty |
-| COMMERCIAL_NACOS_SERVER_URL | Commercial Nacos service address | Empty |
-| COMMERCIAL_NACOS_USERNAME | Commercial Nacos username (required for commercial Nacos MCP data import) | Empty |
-| COMMERCIAL_NACOS_PASSWORD | Commercial Nacos password (required for commercial Nacos MCP data import) | Empty |
-| COMMERCIAL_NACOS_ACCESS_KEY | Commercial Nacos AccessKey | Empty |
-| COMMERCIAL_NACOS_SECRET_KEY | Commercial Nacos SecretKey | Empty |
-| USE_AI_GATEWAY | Whether to use AI Gateway (true/false), skips Higress deployment and related initialization scripts if used | false |
-| AI_GATEWAY_ID | AI Gateway instance ID | Empty |
-| AI_GATEWAY_NAME | AI Gateway instance name | Empty |
-| AI_GATEWAY_REGION | AI Gateway region | Empty |
-| AI_GATEWAY_ACCESS_KEY | AI Gateway AccessKey | Empty |
-| AI_GATEWAY_SECRET_KEY | AI Gateway SecretKey | Empty |
-| NACOS_ADMIN_PASSWORD | Nacos administrator password | nacos |
+| HIMARKET_SERVER_IMAGE | HiMarket backend service image | opensource-registry...himarket-server:latest |
+| HIMARKET_ADMIN_IMAGE | HiMarket management console image | opensource-registry...himarket-admin:latest |
+| HIMARKET_FRONTEND_IMAGE | HiMarket frontend service image | opensource-registry...himarket-frontend:latest |
+| MYSQL_IMAGE | MySQL image address | opensource-registry...mysql:latest |
+| NACOS_IMAGE | Nacos image address | nacos-registry...nacos-server:v3.2.1-2026.03.30 |
+| HIGRESS_IMAGE | Higress image address | higress-registry...all-in-one:latest |
+| REDIS_IMAGE | Redis image address | higress-registry...redis-stack-server:7.4.0-v3 |
+| SANDBOX_IMAGE | Sandbox image address | opensource-registry...sandbox:latest |
+| MYSQL_ROOT_PASSWORD | MySQL root password | Auto-generated |
+| MYSQL_PASSWORD | MySQL application password | Auto-generated |
+| NACOS_ADMIN_PASSWORD | Nacos admin password | Auto-generated |
 | HIGRESS_USERNAME | Higress login username | admin |
-| HIGRESS_PASSWORD | Higress login password | admin |
-| ADMIN_USERNAME | Backend administrator username | admin |
-| ADMIN_PASSWORD | Backend administrator password | admin |
-| FRONT_USERNAME | Frontend default username | demo |
-| FRONT_PASSWORD | Frontend default password | demo123 |
-| NACOS_IMAGE | Nacos image address | nacos-registry.cn-hangzhou.cr.aliyuncs.com/nacos/nacos-server:v3.1.1 |
-| NACOS_AUTH_IDENTITY_KEY | Nacos authentication identity key | serverIdentity |
-| NACOS_AUTH_IDENTITY_VALUE | Nacos authentication identity value | security |
-| NACOS_AUTH_TOKEN | Nacos authentication token | VGhpc0lzTXlDdXN0b21TZWNyZXRLZXkwMTIzNDU2Nzg= |
-| HIGRESS_IMAGE | Higress image address | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/all-in-one:latest |
-| HIMARKET_SERVER_IMAGE | Himarket backend service image | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-server:latest |
-| HIMARKET_ADMIN_IMAGE | Himarket management console image | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-admin:latest |
-| HIMARKET_FRONTEND_IMAGE | Himarket frontend service image | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/himarket-frontend:latest |
-| REDIS_IMAGE | Redis image address | higress-registry.cn-hangzhou.cr.aliyuncs.com/higress/redis-stack-server:7.4.0-v3 |
-| MYSQL_IMAGE | MySQL image address | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group/mysql:latest |
+| HIGRESS_PASSWORD | Higress login password | Auto-generated |
+| ADMIN_USERNAME | Backend admin username | admin |
+| ADMIN_PASSWORD | Backend admin password | Auto-generated |
+| FRONT_USERNAME | Frontend default username | user |
+| FRONT_PASSWORD | Frontend default password | Auto-generated |
+| SKIP_AI_MODEL_INIT | Skip AI model initialization | true |
+| AI_MODEL_COUNT | Number of AI models | 0 |
 
+> For the complete list of configuration items, refer to the `.env.example` file. Log file is located at `~/himarket-install-docker.log`.
 
 ## 3. Cloud-Native Deployment with Helm
 
-Helm is a package management system for automating Kubernetes software management and release. Through the Helm one-click deployment script, you can quickly deploy and install HiMarket+Higress+Nacos on a Kubernetes cluster, including ten service components:
+Helm is a package manager for Kubernetes. The `install.sh` script enables one-click deployment of HiMarket + Higress + Nacos full-stack services on a K8s cluster, including the following components:
 
 + **HiMarket:**
-    - himarket-server: HiMarket AI open platform backend service;
-    - himarket-admin: HiMarket AI open platform management console, administrators configure Portal through this interface;
-    - himarket-frontend: HiMarket AI open platform frontend service, users browse and use APIs through this interface;
-    - mysql: Optional built-in database.
+    - himarket-server: Backend API service;
+    - himarket-admin: Management console interface;
+    - himarket-frontend: Developer portal interface;
+    - mysql: Optional built-in database;
+    - sandbox-shared: Remote sandbox service.
 + **Higress:**
-    - higress-console: Console, users browse and use Higress service through this interface;
-    - higress-controller: Control plane component, responsible for managing configuration distribution;
-    - higress-gateway: Data plane component, responsible for carrying data traffic;
+    - higress-console: Higress console;
+    - higress-controller: Control plane component;
+    - higress-gateway: Data plane component;
     - redis-stack-server: Cache component.
 + **Nacos:**
     - nacos: Nacos application;
@@ -169,98 +170,81 @@ Helm is a package management system for automating Kubernetes software managemen
 
 **Service Type Description:**
 
-Default is LoadBalancer type service, suitable for cloud environments (Alibaba Cloud ACK, AWS EKS, etc.). If your environment does not support LoadBalancer (such as local minikube, self-built clusters), you can use NodePort or port forwarding to access. After configuring Himarket in the backend, resolve the domain name to the himarket-frontend service access address, and users can access the frontend site through the domain name.
+Default is LoadBalancer type service, suitable for cloud environments (Alibaba Cloud ACK, AWS EKS, etc.). If your environment does not support LoadBalancer (such as local minikube, self-built clusters), you can use NodePort or port forwarding to access.
 
 ### Installation Commands
 
-**Environment Dependencies:** kubectl, python3/python, curl, jq
+**Environment Dependencies:** kubectl (connected to a K8s cluster), helm, curl, jq, python3
 
-**One-Click Startup:** Use the `deploy.sh` script to deploy HiMarket to a Kubernetes cluster.
+**Interactive Deployment (Recommended):**
 
 ```bash
 # Clone project
 git clone https://github.com/higress-group/himarket.git
-cd himarket/deploy/helm/scripts
+cd himarket/deploy/helm
 
-# Deploy full-stack services and initialize
-./deploy.sh install
-
-# Or deploy only Himarket services (without Nacos/Higress)
-./deploy.sh himarket-only
-
-# Uninstall
-./deploy.sh uninstall
+# Interactive deployment
+./install.sh
 ```
 
-The script will **execute data initialization hooks** after deployment: performs login data initialization, example MCP data initialization, and API product data initialization. Note that the script includes **deployment** and **data initialization** parts. Data initialization execution does not block deployment. If data initialization hooks fail, they can be retried in `/scripts/hooks/post_ready.d`. For example:
+**Non-Interactive Mode (CI/CD):**
 
 ```bash
-cd helm/scripts/hooks/post_ready.d
+cp .env.example ~/himarket-install.env
+# Edit ~/himarket-install.env to modify configurations
+./install.sh -n
+```
 
-# Retry failed script
+**Uninstall:**
+
+```bash
+./install.sh --uninstall
+```
+
+**Upgrade:**
+
+Re-run `./install.sh`, and the script will automatically detect existing deployments and provide upgrade options. Configurations are saved to `~/himarket-install.env` and reused for subsequent upgrades.
+
+**Retry Data Initialization:**
+
+```bash
+# Retry initialization hooks only, without redeploying services
+./install.sh --init-data
+
+# Or manually execute individual hooks
+cd hooks/post_ready.d
 ./10-init-nacos-admin.sh
 ```
 
 ### Installation Configuration
 
-Related configurations are centralized in the `scripts/data/.env` file:
+The configuration file is `~/himarket-install.env` (auto-generated in interactive mode), or can be copied from the `.env.example` template. Key configuration items:
 
-```bash
-cd helm/scripts/data
-vi .env
-```
-
-| Configuration Name | Configuration Description | **Default Value** |
+| Configuration Name | Description | Default Value |
 | --- | --- | --- |
-| NAMESPACE | Kubernetes namespace | himarket-system |
-| HIMARKET_ONLY | Deploy only Himarket (skip Nacos/Higress) | false |
-| HIMARKET_IMAGE_TAG | Himarket image tag | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL image tag | latest |
-| HIMARKET_MYSQL_ENABLED | Whether to use built-in MySQL (true/false) | true |
-| EXTERNAL_DB_HOST | External database address (used when HIMARKET_MYSQL_ENABLED=false) | Your_External_DB_Host |
-| EXTERNAL_DB_PORT | External database port | 3306 |
-| EXTERNAL_DB_NAME | External database name | Your_DB_Name |
-| EXTERNAL_DB_USERNAME | External database username | Your_DB_Username |
-| EXTERNAL_DB_PASSWORD | External database password | Your_DB_Password |
-| USE_COMMERCIAL_NACOS | Whether to use commercial Nacos (true/false), skips Nacos deployment if used | false |
-| COMMERCIAL_NACOS_NAME | Commercial Nacos instance name | Empty |
-| COMMERCIAL_NACOS_SERVER_URL | Commercial Nacos service address | Empty |
-| COMMERCIAL_NACOS_USERNAME | Commercial Nacos username (required for commercial Nacos MCP data import) | Empty |
-| COMMERCIAL_NACOS_PASSWORD | Commercial Nacos password (required for commercial Nacos MCP data import) | Empty |
-| COMMERCIAL_NACOS_ACCESS_KEY | Commercial Nacos AccessKey | Empty |
-| COMMERCIAL_NACOS_SECRET_KEY | Commercial Nacos SecretKey | Empty |
-| USE_AI_GATEWAY | Whether to use AI Gateway (true/false), skips Higress deployment and related initialization scripts if used | false |
-| AI_GATEWAY_ID | AI Gateway instance ID | Empty |
-| AI_GATEWAY_NAME | AI Gateway instance name | Empty |
-| AI_GATEWAY_REGION | AI Gateway region | Empty |
-| AI_GATEWAY_ACCESS_KEY | AI Gateway AccessKey | Empty |
-| AI_GATEWAY_SECRET_KEY | AI Gateway SecretKey | Empty |
-| NACOS_ADMIN_PASSWORD | Nacos administrator password | nacos |
+| NAMESPACE | Kubernetes namespace | himarket |
+| HIMARKET_HUB | HiMarket image registry address | opensource-registry...higress-group |
+| HIMARKET_IMAGE_TAG | HiMarket image tag | latest |
+| NACOS_VERSION | Nacos image version | v3.2.1-2026.03.30 |
+| MYSQL_ROOT_PASSWORD | MySQL root password | Auto-generated |
+| MYSQL_PASSWORD | MySQL application password | Auto-generated |
+| NACOS_ADMIN_PASSWORD | Nacos admin password | Auto-generated |
 | HIGRESS_USERNAME | Higress login username | admin |
-| HIGRESS_PASSWORD | Higress login password | admin |
-| ADMIN_USERNAME | Backend administrator username | admin |
-| ADMIN_PASSWORD | Backend administrator password | admin |
-| FRONT_USERNAME | Frontend default username | demo |
-| FRONT_PASSWORD | Frontend default password | demo123 |
-| NACOS_VERSION | Nacos image version | v3.1.1 |
-| NACOS_IMAGE_REGISTRY | Nacos image registry | nacos-registry.cn-hangzhou.cr.aliyuncs.com |
-| NACOS_IMAGE_REPOSITORY | Nacos image address | nacos/nacos-server |
-| HIGRESS_REPO_NAME | Higress Helm repository name | higress.io |
-| HIGRESS_REPO_URL | Higress Helm repository URL | https://higress.cn/helm-charts |
-| HIGRESS_CHART_REF | Higress Chart reference | higress.io/higress |
-| NACOS_REPO_NAME | Nacos Helm repository name | ygqygq2 |
-| NACOS_REPO_URL | Nacos Helm repository URL | https://ygqygq2.github.io/charts/ |
-| NACOS_CHART_REF | Nacos Chart reference | ygqygq2/nacos |
-| HIMARKET_HUB | Himarket image registry address | opensource-registry.cn-hangzhou.cr.aliyuncs.com/higress-group |
-| HIMARKET_IMAGE_TAG | Himarket image tag | latest |
-| HIMARKET_MYSQL_IMAGE_TAG | MySQL image tag | latest |
+| HIGRESS_PASSWORD | Higress login password | Auto-generated |
+| ADMIN_USERNAME | Backend admin username | admin |
+| ADMIN_PASSWORD | Backend admin password | Auto-generated |
+| FRONT_USERNAME | Frontend default username | user |
+| FRONT_PASSWORD | Frontend default password | Auto-generated |
+| MYSQL_STORAGE_CLASS | MySQL storage class | alicloud-disk-essd |
+| MYSQL_STORAGE_SIZE | MySQL storage size | 50Gi |
+| SANDBOX_STORAGE_CLASS | Sandbox storage class | alicloud-disk-essd |
+| SANDBOX_STORAGE_SIZE | Sandbox storage size | 50Gi |
+| HIGRESS_INGRESS_CLASS | Higress IngressClass | himarket |
+| SKIP_AI_MODEL_INIT | Skip AI model initialization | true |
+| AI_MODEL_COUNT | Number of AI models | 0 |
 
-
-Note: HiMarket's Helm package is adapted for Alibaba Cloud ACK cluster use. The storage class persistence.storageClass: "alicloud-disk-essd" value in the /helm/values.yaml file needs to be adjusted according to the actual environment.
+> For the complete list of configuration items, refer to the `.env.example` file. Storage classes `MYSQL_STORAGE_CLASS` and `SANDBOX_STORAGE_CLASS` should be adjusted according to your K8s environment. Log file is located at `~/himarket-install.log`.
 
 ## 4. Cloud Platform Deployment (Alibaba Cloud)
 
 Alibaba Cloud Computing Nest supports the out-of-the-box version of this project, with one-click deployment of the community edition: [![Deploy on AlibabaCloud ComputeNest](https://service-info-public.oss-cn-hangzhou.aliyuncs.com/computenest.svg)](https://computenest.console.aliyun.com/service/instance/create/cn-hangzhou?type=user&ServiceId=service-b96fefcb748f47b7b958)
-
-
-


### PR DESCRIPTION
## Summary
- 重写 Docker Compose 和 Helm 部署章节，反映新的交互式 `install.sh` 部署脚本工作流
- 更新服务组件列表（新增 Sandbox 服务、HiMarket Admin 端口变更为 5175、Nacos 端口更新等）
- 简化配置表，密码默认改为自动生成，新增 `--uninstall`、`--init-data`、非交互模式等 CLI 选项说明
- 同步更新中文版和英文版文档

## Test plan
- [ ] 验证中文文档 `docs/ai/himarket/himarket-deployment.md` 内容正确
- [ ] 验证中文文档 `docs/himarket/himarket-deployment.md` 内容正确
- [ ] 验证英文文档 `en/docs/ai/himarket/himarket-deployment.md` 内容正确
- [ ] 确认配置表中的端口号和服务名称与实际部署脚本一致

🤖 Generated with [Qoder][https://qoder.com]