### PR TITLE
chore(analytics): rotate Google Analytics measurement ID to G-34NDHLSRQX

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -154,7 +154,7 @@ export default defineConfig({
         {
           tag: "script",
           attrs: {
-            src: "https://www.googletagmanager.com/gtag/js?id=G-YHS75WKFBR",
+            src: "https://www.googletagmanager.com/gtag/js?id=G-34NDHLSRQX",
             async: true,
           },
         },

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -58,4 +58,4 @@
   }
   gtag("js", new Date());
 
-  gtag("config", "G-YHS75WKFBR");
+  gtag("config", "G-34NDHLSRQX");


### PR DESCRIPTION
## Ⅰ. Describe what this PR did

Rotate the site's Google Analytics 4 measurement ID:

- `G-YHS75WKFBR` → **`G-34NDHLSRQX`**

Two locations are updated, both pointing to the same new ID:

- `astro.config.mjs` (Starlight `head:` injection of `gtag.js`)
- `public/scripts.js` (`dataLayer` init + `gtag('config', ...)` call)

No other behavior changes — the snippet shape, load order, and the rest of `scripts.js` (Alibaba `aplus` / `AES` tracker / Baidu Hm) are intentionally untouched in this PR.

## Ⅱ. Why

The previous GA4 property (`G-YHS75WKFBR`) was set up by an early maintainer who is no longer reachable. The current project team has **no admin access** to that property and therefore cannot view or manage its data. To unblock the CNCF Sandbox onboarding step **"Transfer website analytics"** ([cncf/sandbox#481](https://github.com/cncf/sandbox/issues/481)), we created a fresh GA4 property (`G-34NDHLSRQX`) under a project-owned Google account. After this PR is merged we will add `projects@cncf.io` as an Administrator on the new GA Account, so the CNCF can complete the transfer to a CNCF-managed account.

## Ⅲ. Does this pull request fix one issue?

Related to [cncf/sandbox#481](https://github.com/cncf/sandbox/issues/481) — the "Transfer website analytics" checklist item.

## Ⅳ. Why don't you add test cases (unit test/integration test)?

Configuration-only change — there is no test surface for an analytics tracking ID. Verification is done at runtime (see Ⅴ below).

## Ⅴ. Describe how to verify it

Local:

```bash
npm install
npm run dev
```

Open the dev URL in a browser, open **DevTools → Network**, filter by `collect`, refresh the page. You should see one or more requests to `https://www.google-analytics.com/g/collect?...&tid=G-34NDHLSRQX&...`. Then check **GA → Realtime** for the new property — within ~30s a single active user should appear.

Production: after merge + deploy, repeat the same Realtime check on `https://higress.ai`.

## Ⅵ. Special notes for reviews

- The new measurement ID is owned by the current Higress maintainers (project Google account); access plan and CNCF transfer plan are tracked in the onboarding issue.
- Follow-ups (intentionally **not** in this PR, to keep it minimal):
  - Consolidate `gtag` initialization into a single place (currently split between `astro.config.mjs` and `public/scripts.js`).
  - Decide whether to keep / scope-down the Alibaba and Baidu trackers in `public/scripts.js` once the project is fully under CNCF.
