### PR TITLE
chore(analytics): consolidate GA into a shared component and cover all pages (follow-up to #524)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,7 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 import { writeLlmsTxt } from "./src/utils/llmsTxtGenerator.ts";
+import { GA_MEASUREMENT_ID } from "./src/config/analytics.mjs";
 
 // 加载所有 sidebar 配置
 const zhDocsSidebar = loadSidebarConfig("root", "docs");
@@ -151,12 +152,19 @@ export default defineConfig({
             href: "https://img.alicdn.com/imgextra/i4/O1CN01AViQMJ1J2lY4OPRgv_!!6000000000971-2-tps-376-375.png",
           },
         },
+        // Google Analytics (gtag.js) — measurement ID lives in src/config/analytics.mjs
+        // so it stays in sync with src/components/analytics/GoogleAnalytics.astro
+        // (used by non-Starlight pages via src/layout/siteLayout.astro).
         {
           tag: "script",
           attrs: {
-            src: "https://www.googletagmanager.com/gtag/js?id=G-34NDHLSRQX",
+            src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
             async: true,
           },
+        },
+        {
+          tag: "script",
+          content: `window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', '${GA_MEASUREMENT_ID}');`,
         },
         {
           tag: "script",

--- a/public/scripts.js
+++ b/public/scripts.js
@@ -51,11 +51,8 @@
       s.parentNode.insertBefore(hm, s);
   })();
 
-
-  window.dataLayer = window.dataLayer || [];
-  function gtag() {
-      dataLayer.push(arguments);
-  }
-  gtag("js", new Date());
-
-  gtag("config", "G-34NDHLSRQX");
+  // Google Analytics initialization moved to src/components/analytics/GoogleAnalytics.astro
+  // (via src/config/analytics.mjs). The gtag.js loader is now injected in two places:
+  //   - astro.config.mjs head[]                (Starlight-rendered docs pages)
+  //   - src/layout/siteLayout.astro <head>     (marketing / blog / etc.)
+  // Keeping the analytics ID in a single source-of-truth file.

--- a/src/components/analytics/GoogleAnalytics.astro
+++ b/src/components/analytics/GoogleAnalytics.astro
@@ -1,0 +1,11 @@
+---
+import { GA_MEASUREMENT_ID } from "../../config/analytics.mjs";
+---
+<!-- Google Analytics (gtag.js) -->
+<script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}></script>
+<script is:inline define:vars={{ measurementId: GA_MEASUREMENT_ID }}>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+  gtag('config', measurementId);
+</script>

--- a/src/config/analytics.mjs
+++ b/src/config/analytics.mjs
@@ -1,0 +1,10 @@
+// Single source of truth for the site's analytics configuration.
+//
+// Owned by the Higress maintainers (project-shared Google account); see
+// cncf/sandbox#481 for the CNCF onboarding context.
+//
+// Used by:
+//   - astro.config.mjs (head[] injection for Starlight-rendered docs pages)
+//   - src/components/analytics/GoogleAnalytics.astro (for marketing/blog/etc.
+//     pages rendered by src/layout/siteLayout.astro)
+export const GA_MEASUREMENT_ID = "G-34NDHLSRQX";

--- a/src/layout/siteLayout.astro
+++ b/src/layout/siteLayout.astro
@@ -4,6 +4,7 @@ import Navbar from '../container/Navbar.astro';
 import PageFooter from '../container/page-footer.astro';
 import TopBar from '@/components/top-bar/topBar.astro';
 import ScrollProgress from '../components/scroll-progress/ScrollProgress.astro';
+import GoogleAnalytics from '../components/analytics/GoogleAnalytics.astro';
 import { useTranslations } from "@/i18n/utils";
 const locale = Astro.currentLocale || 'root';
 const t = useTranslations(locale);
@@ -93,6 +94,8 @@ const headEntry = {
       rel="icon"
       href="https://img.alicdn.com/imgextra/i4/O1CN01AViQMJ1J2lY4OPRgv_!!6000000000971-2-tps-376-375.png"
     />
+
+    <GoogleAnalytics />
 
   </head>
   <body>


### PR DESCRIPTION
> Follow-up to #524.

## Ⅰ. Describe what this PR did

Consolidate Google Analytics into a shared component and **cover all visitor-facing pages**, not just the docs.

After #524 we verified that the new measurement ID was live on `/docs/*` only — the home page, all marketing pages, blog, plugins, glossary and comparison pages still had **no GA tracking at all** (a pre-existing gap that long predates this rotation, but became visible during the rotation work).

This PR fixes that gap and removes the duplication of the measurement ID at the same time:

- `src/config/analytics.mjs` (new) — single source of truth for the GA4 measurement ID.
- `src/components/analytics/GoogleAnalytics.astro` (new) — small reusable component that renders the `gtag.js` loader and the `dataLayer`/init inline script using the centralized constant.
- `astro.config.mjs` — imports the constant; Starlight's `head[]` injection now uses both the loader **and** the inline init (previously only the loader was injected here, and the init lived in `public/scripts.js`).
- `src/layout/siteLayout.astro` — renders `<GoogleAnalytics />` right before `</head>`, so the home page, all marketing pages, blog, plugins, glossary and comparison pages now report to GA4 as well. `BlogLayout` already wraps `SiteLayout`, so it's covered transitively.
- `public/scripts.js` — removes the duplicated `dataLayer` / `gtag('config', ...)` block. The Alibaba `aplus` / `AES` tracker and Baidu `_hmt` code paths in `scripts.js` are intentionally left untouched.

After this PR, the GA4 measurement ID appears **exactly once** in the repo (`src/config/analytics.mjs`).

## Ⅱ. Why

1. **Coverage**: visitors landing on `https://higress.ai/`, `/ai-gateway`, `/api-gateway`, `/himarket`, `/hiclaw`, `/blog/*`, `/plugins/*`, `/comparison/*`, `/glossary/*` were not being counted at all. After this PR, GA4 reports represent the whole site.
2. **Maintainability**: rotating the measurement ID in the future is a one-line change in `src/config/analytics.mjs` instead of touching three files (avoiding the kind of split #524 had to do).
3. **CNCF onboarding**: relates to the "Transfer website analytics" item in [cncf/sandbox#481](https://github.com/cncf/sandbox/issues/481) — once landed we can hand the GA Account over to CNCF and have a clean, consistent setup.

## Ⅲ. Does this pull request fix one issue?

Follow-up to #524. Related to [cncf/sandbox#481](https://github.com/cncf/sandbox/issues/481).

## Ⅳ. Why don't you add test cases (unit test/integration test)?

Configuration / wiring change; there is no unit-test surface for analytics injection. Verification is runtime (see Ⅴ).

## Ⅴ. Describe how to verify it

Local:

```bash
npm install
npm run dev
```

Open the dev URL, then in DevTools → Network filter by `collect`, and visit each of the page categories below. Each should produce at least one request to `https://www.google-analytics.com/g/collect?...&tid=G-34NDHLSRQX&...`:

- `/` (home)
- `/en/`
- `/ai-gateway`, `/api-gateway`, `/himarket`, `/hiclaw`
- `/blog/`
- `/plugins/`
- `/glossary/`
- `/comparison/`
- `/docs/latest/overview/what-is-higress/` (regression check — should still work as it does post-#524)

Then check **GA → Realtime** for the new property — within ~30s a single active user should appear; navigating across the above paths should keep it as a single session.

Production: after merge + deploy, repeat the same Realtime check on `https://higress.ai`.

## Ⅵ. Special notes for reviews

- No change to the Alibaba `aplus` / `AES` tracker or Baidu `_hmt` code paths — they remain confined to `public/scripts.js` and continue to load only on Starlight (docs) pages, exactly as before.
- The two `<script>` injections (Starlight `head[]` for docs, `<GoogleAnalytics />` in `siteLayout.astro` for non-docs) do **not** overlap: docs pages do not use `siteLayout.astro`, and pages using `siteLayout.astro` do not go through Starlight, so there is no risk of double-firing GA.
- The component uses `is:inline define:vars={{ measurementId: GA_MEASUREMENT_ID }}` so the constant is properly serialized into the inline script at build time.
