### PR TITLE
fix(home): refresh homepage news links

### DIFF
--- a/src/container/main-hero.astro
+++ b/src/container/main-hero.astro
@@ -10,22 +10,22 @@ const newsItems = [
   {
     title: t('home.news.1.title'),
     content: t('home.news.1.content'),
-    href: localizeUrl("/blog/higress-gvr7dx_awbbpb_ra13rhoba09uz5ys", locale),
+    href: localizeUrl("/blog/higress-mmse_awbbpb_qwo0xq9sf9bc9i21", locale),
   },
   {
     title: t('home.news.2.title'),
     content: t('home.news.2.content'),
-    href: localizeUrl("/blog/higress-gvr7dx_awbbpb_dlf3hnl3rs3sdt73", locale),
+    href: localizeUrl("/blog/higress-mmse_awbbpb_fcqs5xkqgc1imf5t", locale),
   },
   {
     title: t('home.news.3.title'),
     content: t('home.news.3.content'),
-    href: localizeUrl("/blog/higress-gvr7dx_awbbpb_ortukqsuia6ahf2v", locale),
+    href: localizeUrl("/blog/higress-mmse_awbbpb_bkbercpqlurl6nqy", locale),
   },
   {
     title: t('home.news.4.title'),
     content: t('home.news.4.content'),
-    href: localizeUrl("/blog/higress-gvr7dx_awbbpb_qsp4dkv4iigo6u70", locale),
+    href: localizeUrl("/blog/higress-mmse_awbbpb_yafyyrc3t5wh0u55", locale),
   }
 ];
 ---

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -500,14 +500,14 @@ export default {
 	'home.hero.news.label': 'News',
 
 	// Home News
-	'home.news.1.title': '200,000 RMB Prize Pool',
-	'home.news.1.content': 'Congratulations to the winners! The award list for the Higress AI Gateway Development Challenge has been announced.',
-	'home.news.2.title': 'Original Comic',
-	'home.news.2.content': 'This year of AI Gateway has become a microcosm of AI evolution.',
-	'home.news.3.title': 'A Simpler Way',
-	'home.news.3.content': 'With Nginx Ingress retiring, it\'s time to clarify these easily confused concepts.',
-	'home.news.4.title': 'Whitepaper Comparison',
-	'home.news.4.content': 'The State of AI Agent Engineering in 2025.',
+	'home.news.1.title': 'Higress v2.2.4',
+	'home.news.1.content': 'Key changes: new MCP capabilities and Gateway API inference extensions.',
+	'home.news.2.title': 'MCP Server Update',
+	'home.news.2.content': 'MCP 2026-07-28 support with compatibility for existing protocols.',
+	'home.news.3.title': 'MCP Returns to HTTP',
+	'home.news.3.content': 'Why sound architecture design and engineering practice remain scarce.',
+	'home.news.4.title': 'Qwen3Guard Integration',
+	'home.news.4.content': 'Bring AI content safety into the gateway path without application changes.',
 
 	// Gateway Solution
 	'home.gateway.solution.eyebrow': 'AI GATEWAY ARCHITECTURE',

--- a/src/i18n/zh-cn.ts
+++ b/src/i18n/zh-cn.ts
@@ -506,14 +506,14 @@ export default {
 	'home.hero.news.label': 'News',
 
 	// 首页新闻
-	'home.news.1.title': '奖金 20 万',
-	'home.news.1.content': '恭喜以下选手！Higress AI 网关开发挑战赛获奖名单公布',
-	'home.news.2.title': '自制漫画',
-	'home.news.2.content': 'AI 网关这一年，成了 AI 进化的缩影',
-	'home.news.3.title': '一种更简单的方式',
-	'home.news.3.content': ' 应对 Nginx Ingress 退役，是时候理清这些易混淆的概念了',
-	'home.news.4.title': '与白皮书比对',
-	'home.news.4.content': '2025 智能体工程现状',
+	'home.news.1.title': 'Higress v2.2.4',
+	'home.news.1.content': '从新版 MCP 到 Gateway API 推理扩展，读懂关键变化',
+	'home.news.2.title': 'MCP Server 更新',
+	'home.news.2.content': '拥抱 MCP 2026-07-28，兼容既有协议',
+	'home.news.3.title': 'MCP 重回 HTTP',
+	'home.news.3.content': '再次证明架构设计和工程实践才是稀缺资源',
+	'home.news.4.title': '接入 Qwen3Guard',
+	'home.news.4.content': '不改一行业务代码，把 AI 内容安全做进网关主链路',
 
 	// 网关解决方案
 	'home.gateway.solution.eyebrow': 'AI GATEWAY ARCHITECTURE',


### PR DESCRIPTION
## Summary
- refresh the four homepage News card destinations
- align Chinese and English card copy with the linked articles

## Validation
- npm run build