### PR TITLE
fix(docs): update Gateway API compatibility matrix and TCP route guide

### DIFF
--- a/src/content/docs/docs/latest/ops/deploy-by-helm.md
+++ b/src/content/docs/docs/latest/ops/deploy-by-helm.md
@@ -68,14 +68,15 @@ helm upgrade higress -n higress-system --set global.enableIstioAPI=true higress.
 
 集群里需要提前安装好 Gateway API 的 CRD：https://github.com/kubernetes-sigs/gateway-api/releases
 
-> 注：Higress 最高支持的 Gateway API 版本如下：
-> - \>= 2.2.x：1.4.0
-> - <= 2.1.x：1.0.0
+> 注：Higress 兼容的 Gateway API 版本如下：
+> - ≥ 2.2.4：1.6.0
+> - ≥ 2.2.0 且 < 2.2.4：1.4.0
+> - ≤ 2.1.x：1.0.0
 
-以1.4.0为例：
+以1.6.0为例：
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
 ```
 
 这种模式下，需要更新 Higress 的部署参数：

--- a/src/content/docs/docs/latest/ops/how-tos/tcp-route.md
+++ b/src/content/docs/docs/latest/ops/how-tos/tcp-route.md
@@ -7,6 +7,8 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 # 配置 TCP 四层路由
 
+**注意：**本文档不适用于版本 ≥ 2.2.0 且 < 2.2.4 的 Higress。如果你的 Higress 版本处于这一区间内，建议升级至 2.2.4 或更高版本。
+
 ## 前置准备
 
 1. Higress 安装在 K8s 内的 higress-system 命名空间下，网关的 Service 名称为 higress-gateway；
@@ -15,14 +17,18 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 ## 配置步骤
 
+> 不同 Higress 版本的具体配置操作存在些许差异。请务必注意。
+
 ### 1. 创建 GatewayClass
+
+> 当 Higress 版本 ≥ 2.2.0 时，本步骤无需执行。请直接跳转至下一步。
 
 1. 创建 `gatewayclass.yaml` 文件，并写入以下内容：
     ```yaml
     apiVersion: gateway.networking.k8s.io/v1
     kind: GatewayClass
     metadata:
-      name: higress-gateway
+      name: higress
     spec:
       controllerName: "higress.io/gateway-controller"
     ```
@@ -41,7 +47,7 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
       name: higress-gateway
       namespace: higress-system
     spec:
-      gatewayClassName: higress-gateway
+      gatewayClassName: higress
       listeners:
       - name: default-tcp
         protocol: TCP
@@ -88,22 +94,40 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 ### 4. 创建 TCPRoute
 
 1. 创建 `tcproute.yaml` 文件，并写入以下内容：
-    ```yaml
-    apiVersion: gateway.networking.k8s.io/v1alpha2
-    kind: TCPRoute
-    metadata:
-      name: tcp-echo
-      namespace: default
-    spec:
-      parentRefs:
-      - name: higress-gateway
-        namespace: higress-system
-        port: 9000
-      rules:
-      - backendRefs:
-        - name: tcp-echo
-          port: 9000
-    ```
+    1. Higress ≥ 2.2.4 + Gateway API 1.6.0
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: TCPRoute
+        metadata:
+          name: tcp-echo
+          namespace: default
+        spec:
+          parentRefs:
+          - name: higress-gateway
+            namespace: higress-system
+            port: 9000
+          rules:
+          - backendRefs:
+            - name: tcp-echo
+              port: 9000
+        ```
+    2. Higress < 2.2.4 + Gateway API ≤ 1.4.0
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1alpha2
+        kind: TCPRoute
+        metadata:
+          name: tcp-echo
+          namespace: default
+        spec:
+          parentRefs:
+          - name: higress-gateway
+            namespace: higress-system
+            port: 9000
+          rules:
+          - backendRefs:
+            - name: tcp-echo
+              port: 9000
+        ```
 2. 执行命令，将以上配置写入 K8s 集群：
     ```bash
     kubectl apply -f tcproute.yaml

--- a/src/content/docs/en/docs/latest/ops/deploy-by-helm.md
+++ b/src/content/docs/en/docs/latest/ops/deploy-by-helm.md
@@ -68,14 +68,15 @@ helm upgrade higress -n higress-system --set global.enableIstioAPI=true higress.
 
 The cluster needs to have Gateway API CRDs installed in advance: https://github.com/kubernetes-sigs/gateway-api/releases
 
-> Note: The highest version of Gateway API supported by Higress is as following:
-> - \>= 2.2.x：1.4.0
-> - <= 2.1.x: 1.0.0
+> Note: The Gateway API versions compatible with Higress are as follows:
+> - ≥ 2.2.4: 1.6.0
+> - ≥ 2.2.0 and < 2.2.4: 1.4.0
+> - ≤ 2.1.x: 1.0.0
 
-For example, for version 1.4.0:
+For example, for version 1.6.0:
 
 ```bash
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.4.0/experimental-install.yaml
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.0/experimental-install.yaml
 ```
 
 In this mode, you need to update Higress deployment parameters:

--- a/src/content/docs/en/docs/latest/ops/how-tos/tcp-route.md
+++ b/src/content/docs/en/docs/latest/ops/how-tos/tcp-route.md
@@ -7,6 +7,8 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 # Configure a TCP Layer-4 Route
 
+**Note:** This document does not apply to Higress versions ≥ 2.2.0 and < 2.2.4. If your Higress version falls within this range, it is recommended to upgrade to 2.2.4 or higher.
+
 ## Prerequisites
 
 1. Higress is installed in the higress-system namespace in K8s, with the gateway's Service name being higress-gateway;
@@ -15,14 +17,18 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 
 ## Configuration Steps
 
+> The specific configuration steps differ slightly across Higress versions. Please pay close attention.
+
 ### 1. Create GatewayClass
+
+> When the Higress version is ≥ 2.2.0, this step is not required. Please skip directly to the next step.
 
 1. Create a `gatewayclass.yaml` file with the following content:
     ```yaml
     apiVersion: gateway.networking.k8s.io/v1
     kind: GatewayClass
     metadata:
-      name: higress-gateway
+      name: higress
     spec:
       controllerName: "higress.io/gateway-controller"
     ```
@@ -41,7 +47,7 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
       name: higress-gateway
       namespace: higress-system
     spec:
-      gatewayClassName: higress-gateway
+      gatewayClassName: higress
       listeners:
       - name: default-tcp
         protocol: TCP
@@ -88,22 +94,40 @@ custom_edit_url: https://github.com/higress-group/higress-group.github.io/blob/m
 ### 4. Create TCPRoute
 
 1. Create a `tcproute.yaml` file with the following content:
-    ```yaml
-    apiVersion: gateway.networking.k8s.io/v1alpha2
-    kind: TCPRoute
-    metadata:
-      name: tcp-echo
-      namespace: default
-    spec:
-      parentRefs:
-      - name: higress-gateway
-        namespace: higress-system
-        port: 9000
-      rules:
-      - backendRefs:
-        - name: tcp-echo
-          port: 9000
-    ```
+    1. Higress ≥ 2.2.4 + Gateway API 1.6.0
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1
+        kind: TCPRoute
+        metadata:
+          name: tcp-echo
+          namespace: default
+        spec:
+          parentRefs:
+          - name: higress-gateway
+            namespace: higress-system
+            port: 9000
+          rules:
+          - backendRefs:
+            - name: tcp-echo
+              port: 9000
+        ```
+    2. Higress < 2.2.4 + Gateway API ≤ 1.4.0
+        ```yaml
+        apiVersion: gateway.networking.k8s.io/v1alpha2
+        kind: TCPRoute
+        metadata:
+          name: tcp-echo
+          namespace: default
+        spec:
+          parentRefs:
+          - name: higress-gateway
+            namespace: higress-system
+            port: 9000
+          rules:
+          - backendRefs:
+            - name: tcp-echo
+              port: 9000
+        ```
 2. Execute the command to apply the configuration to the K8s cluster:
     ```bash
     kubectl apply -f tcproute.yaml


### PR DESCRIPTION
## Summary

- Update Gateway API compatibility matrix in `deploy-by-helm.md` to add support for Higress ≥ 2.2.4 (Gateway API 1.6.0) and clarify the ≥ 2.2.0, < 2.2.4 transition range
- Refresh `tcp-route.md`: rename GatewayClass from `higress-gateway` to `higress` (auto-created in 2.2.0+), mark the manual GatewayClass step as skippable for Higress ≥ 2.2.0, and split the TCPRoute YAML into the v1 (1.6.0) and v1alpha2 (≤ 1.4.0) variants
- Add a top-of-page note recommending an upgrade for users on Higress 2.2.0–2.2.4
- Sync all changes between the zh-cn and English versions

## Changes

- `src/content/docs/docs/latest/ops/deploy-by-helm.md`
- `src/content/docs/docs/latest/ops/how-tos/tcp-route.md`
- `src/content/docs/en/docs/latest/ops/deploy-by-helm.md`
- `src/content/docs/en/docs/latest/ops/how-tos/tcp-route.md`

## Test Plan

- [ ] Verify the compatibility matrix renders correctly on the docs site
- [ ] Verify GatewayClass YAML example matches the new naming convention (`higress`)
- [ ] Verify both TCPRoute YAML variants apply cleanly against a test cluster
- [ ] Confirm zh-cn and en versions are in sync